### PR TITLE
Update dbArchive to new JSON format from terraform-modules/clod_sql

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,17 +94,41 @@ local BaseApp = {
 ]
 ```
 
-### jsonnet API
+### jsonnet argokit API
 
 The following templates are available for use in the `argokit.libsonnet` file:
 
-| Template                   | Description                                                    | Example                                                                                  |
-| -------------------------- | -------------------------------------------------------------- | ---------------------------------------------------------------------------------------- |
-| `argokit.Application`      | Creates a Skiperator application                               | See above                                                                                |
-| `argokit.GSMSecretStore`   | Creates a Google Secret Manager External Secrets `SecretStore` | [examples/jsonnet/secretstore-gsm.jsonnet](examples/jsonnet/secretstore-gsm.jsonnet)     |
-| `argokit.GSMSecret`        | Creates a Google Secret Manager External Secrets `Secret`      | [examples/jsonnet/secretstore-gsm.jsonnet](examples/jsonnet/secretstore-gsm.jsonnet)     |
-| `argokit.Roles`            | Creates a set of RBAC roles for this namespace                 | [examples/jsonnet/roles.jsonnet](examples/jsonnet/roles.jsonnet)                         |
+| Template                 | Description                                                    | Example                                                                              |
+|--------------------------|----------------------------------------------------------------|--------------------------------------------------------------------------------------|
+| `argokit.Application`    | Creates a Skiperator application                               | See above                                                                            |
+| `argokit.GSMSecretStore` | Creates a Google Secret Manager External Secrets `SecretStore` | [examples/jsonnet/secretstore-gsm.jsonnet](examples/jsonnet/secretstore-gsm.jsonnet) |
+| `argokit.GSMSecret`      | Creates a Google Secret Manager External Secrets `Secret`      | [examples/jsonnet/secretstore-gsm.jsonnet](examples/jsonnet/secretstore-gsm.jsonnet) |
+| `argokit.Roles`          | Creates a set of RBAC roles for this namespace                 | [examples/jsonnet/roles.jsonnet](examples/jsonnet/roles.jsonnet)                     |
 
+The following templates are available for use in the `dbArchive.libsonnet` file:
+
+| Template                 | Description                                                   | Example                                                                  |
+|--------------------------|---------------------------------------------------------------|--------------------------------------------------------------------------|
+| `dbArchive.dbArchiveJob` | Creates a SKIPJob that creates a sql dump and stores it in S3 | [examples/jsonnet/dbArchive.jsonnet](examples/jsonnet/dbArchive.jsonnet) |
+
+### Input parameters 
+
+#### dbArchiveJob
+
+| Parameter                            | Type    | Default Value            | Description                                                                                                                       |
+|:-------------------------------------|:--------|:-------------------------|:----------------------------------------------------------------------------------------------------------------------------------|
+| **`instanceName`**                   | String  | -                        | **Required.** A unique name for the job and related resources. This name is used as a base for `SKIPJob` and secrets.             |
+| **`schedule`**                       | String  | -                        | **Required.** A cron string defining when the job should run (e.g., `"0 2 * * *"` to run at 02:00 every night).                   |
+| **`databaseIP`**                     | String  | -                        | **Required.** The IP address of the PostgreSQL database to be archived.                                                           |
+| **`gcpS3CredentialsSecret`**         | String  | -                        | **Required.** Name of the secret in GSM containing S3 credentials (`AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`).              |
+| **`databaseName`**                   | String  | -                        | **Required.** Name of the database to be archived.                                                                                |
+| **`archiveUser`**                    | String  | `'postgres'`             | The database user the job should use to connect.                                                                                  |
+| **`serviceAccount`**                 | String  | `'dummyaccount@gcp.iam'` | GCP Service Account used by the Kubernetes job to authenticate against Google Cloud (e.g., to fetch secrets from GSM).            |
+| **`cloudsqlInstanceConnectionName`** | String  | -                        | **Required.** The connection name of the Cloud SQL instance (format: `project:region:instance`). Needed for Cloud SQL Auth Proxy. |
+| **`port`**                           | Integer | `5432`                   | The port number of the PostgreSQL database.                                                                                       |
+| **`S3Host`**                         | String  | `'s3-rin.statkart.no'`   | The hostname of the S3 endpoint where the archive should be stored.                                                               |
+| **`S3DestinationPath`**              | String  | -                        | **Required.** Full S3 path where the database archive should be placed (e.g., `s3://my-bucket/archive/database/`).                |
+| **`fullDump`**                       | Bool    | false                    | Flag to include database roles `without passwords` in the dump.                                                                   |
 
 ## Contributing
 

--- a/examples/jsonnet/dbArchive.jsonnet
+++ b/examples/jsonnet/dbArchive.jsonnet
@@ -1,0 +1,17 @@
+local argokit = import '../../../argokit/jsonnet/argokit.libsonnet';
+local dbArchive = import '../../../argokit/jsonnet/dbArchive.libsonnet';
+
+argokit.ManifestsFrom([
+  // Create a database archive job
+  [argokit.GSMSecretStore("<your-project-id>")],
+  dbArchive.dbArchiveJob(
+    instanceName='<instancename>', // Name of the cloudsql instance in GCP
+    schedule='0 2 * * *',  // At 2:00 every day
+    databaseIP='10.x.x.x', // Private IP of the database instance
+    gcpS3CredentialsSecret='database-s3-access', # Name of secret in GCP with ACCESS_KEY and SECRET_KEY for S3
+    databaseName='my-db', // Individual database name to archive
+    archiveUser='readonly', # User with enough permissions to archive the database
+    cloudsqlInstanceConnectionName='<project>:<region>:<instancename>', // Cloud SQL instance connection name
+    S3DestinationPath='s3://testbackup/arkivjobb-test', // S3 bucket and path where the archive will be stored
+  ),
+])

--- a/jsonnet/dbArchive.libsonnet
+++ b/jsonnet/dbArchive.libsonnet
@@ -7,7 +7,7 @@ local argokit = import './argokit.libsonnet';
     gcpS3CredentialsSecret,
     databaseName,
     archiveUser='postgres',
-    serviceAccount,
+    serviceAccount='dummyaccount@iam.gserviceaccount.com',
     cloudsqlInstanceConnectionName,
     port=5432,
     S3Host='s3-rin.statkart.no',
@@ -15,9 +15,10 @@ local argokit = import './argokit.libsonnet';
     fullDump=false,
   ):
     local this = self;
+    local secretPrefix = 'cloudsql-';
 
-    local instanceSecretName = instanceName + '-instance';
-    local archiveUserSecretName = instanceName + '-' + archiveUser;
+    local instanceSecretName = secretPrefix + instanceName + '-instance';
+    local archiveUserSecretName = secretPrefix + instanceName + '-' + archiveUser;
     [
       {
         apiVersion: 'skiperator.kartverket.no/v1alpha1',


### PR DESCRIPTION
Using the terraform module `terraform-modules/cloud_sql` from version v0.12.0 removes the previous secret format with individual secrets.

This PR modifies the archiveJob to configure externalSecrets on the new JSON format.

Because of very small adoption of the archiveJob, I dropped making a migration-path as one can update the config parameters at the same time as updating the submodule

