### PR TITLE
Restrukturer objekt struktur

### DIFF
--- a/v2/README.md
+++ b/v2/README.md
@@ -98,31 +98,33 @@ local BaseApp = {
 
 The following templates are available for use in the `argokit.libsonnet` file:
 
-| Template                 | Description                                                           | Example                                                                                    |
-|--------------------------|-----------------------------------------------------------------------|--------------------------------------------------------------------------------------------|
-| `argokit.Application`    | Creates a Skiperator application                                      | See above                                                                                  |
-| `argokit.GSMSecretStore` | Creates a Google Secret Manager External Secrets `SecretStore`        | [examples/jsonnet/secretstore-gsm.jsonnet](examples/jsonnet/secretstore-gsm.jsonnet)       |
-| `argokit.GSMSecret`      | Creates a Google Secret Manager External Secrets `Secret`             | [examples/jsonnet/secretstore-gsm.jsonnet](examples/jsonnet/secretstore-gsm.jsonnet)       |
-| `argokit.Roles`          | Creates a set of RBAC roles for this namespace                        | [examples/jsonnet/roles.jsonnet](examples/jsonnet/roles.jsonnet)                           |
-| `argokit.AccessPolicies` | Configures inbound and outbound access policies for services and jobs | [examples/jsonnet/accessPolicies.jsonnet](examples/jsonnet/accessPolicies.jsonnet)         |
-| `argokit.replicas`    | Configures replicasfor the application                           | |
+
+TODO: Rewrite this section
+| Template                    | Description                                                           | Example                                                                                    |
+|-----------------------------|-----------------------------------------------------------------------|--------------------------------------------------------------------------------------------|
+| `argokit.application.new()` | Creates a Skiperator application                                      | See above                                                                                  |
+| `argokit.GSMSecretStore`    | Creates a Google Secret Manager External Secrets `SecretStore`        | [examples/jsonnet/secretstore-gsm.jsonnet](examples/jsonnet/secretstore-gsm.jsonnet)       |
+| `argokit.GSMSecret`         | Creates a Google Secret Manager External Secrets `Secret`             | [examples/jsonnet/secretstore-gsm.jsonnet](examples/jsonnet/secretstore-gsm.jsonnet)       |
+| `argokit.Roles`             | Creates a set of RBAC roles for this namespace                        | [examples/jsonnet/roles.jsonnet](examples/jsonnet/roles.jsonnet)                           |
+| `argokit.AccessPolicies`    | Configures inbound and outbound access policies for services and jobs | [examples/jsonnet/accessPolicies.jsonnet](examples/jsonnet/accessPolicies.jsonnet)         |
+| `argokit.replicas`          | Configures replicasfor the application                           | |
 
 ### argoKit's Replicas API
 **NOTE!** It is not recommended to run with less than 2 replicas... 
 | Template                                | Description                                                     | Example                                                                                    |
 |-----------------------------------------|-----------------------------------------------------------------|--------------------------------------------------------------------------------------------|
-| `argokit.replicas.withReplicas`   | Create replicas for an application with sensible defaults  | [examples/jsonnet/replicasets.jsonnet](v2/examples/replicasets.jsonnet)               |
-| `argokit.replicas.withReplicas`   | Create replicas for an application with memory monitoring  | [examples/jsonnet/replicasets-with-memory.jsonnet](v2/examples/replicasets-with-memory.jsonnet)   |
-| `argokit.replicas.withReplicas`   | Creates a static replica without cpu- and memory monitoring | [examples/jsonnet/replicasets-static.jsonnet](v2/examples/replicasets-static.jsonnet) |
+| `argokit.application.withReplicas`   | Create replicas for an application with sensible defaults  | [examples/jsonnet/replicasets.jsonnet](v2/examples/replicasets.jsonnet)               |
+| `argokit.application.withReplicas`   | Create replicas for an application with memory monitoring  | [examples/jsonnet/replicasets-with-memory.jsonnet](v2/examples/replicasets-with-memory.jsonnet)   |
+| `argokit.application.withReplicas`   | Creates a static replica without cpu- and memory monitoring | [examples/jsonnet/replicasets-static.jsonnet](v2/examples/replicasets-static.jsonnet) |
 
 
 ### argoKit's Environment API
 
-| Template                                         | Description                                                                 | Example                                                                  |
-|--------------------------------------------------|-----------------------------------------------------------------------------|--------------------------------------------------------------------------|
-| `argokit.Env.withVariable`              | Creates environment variables for an app                                    | [examples/jsonnet/envVariables.jsonnet](examples/jsonnet/envVariables.jsonnet) |
-| `argokit.Env.withVariableSecret`        | Creates environment variable from a secret                       | [examples/jsonnet/envVariables.jsonnet](examples/jsonnet/envVariables.jsonnet) |
-| `argokit.Env.withVariablSecret`     | Creates environment variable from a secret for a Job container              | [examples/jsonnet/envVariables.jsonnet](examples/jsonnet/envVariables.jsonnet) |
+| Template                                              | Description                                                    | Example                                                                  |
+|-------------------------------------------------------|----------------------------------------------------------------|--------------------------------------------------------------------------|
+| `argokit.[application\|skipJOB].withVariable`         | Creates environment variables for an app                       | [examples/jsonnet/envVariables.jsonnet](examples/jsonnet/envVariables.jsonnet) |
+| `argokit.[application\|skipJOB].withVariableSecret`   | Creates environment variable from a secret                     | [examples/jsonnet/envVariables.jsonnet](examples/jsonnet/envVariables.jsonnet) |
+| `argokit.[application\|skipJOB].withVariableSecret`   | Creates environment variable from a secret for a Job container | [examples/jsonnet/envVariables.jsonnet](examples/jsonnet/envVariables.jsonnet) |
 
 ---
 The following templates are available for use in the `dbArchive.libsonnet` file:

--- a/v2/examples/accessPolicies-for-job.jsonnet
+++ b/v2/examples/accessPolicies-for-job.jsonnet
@@ -1,12 +1,11 @@
 local argokit = import '../jsonnet/argokit.libsonnet';
 
-local accessPolicies = argokit.accessPolicies;
 
 argokit.skipJob.new('a-cool-app')
-+ accessPolicies.withOutboundSkipApp('appJob', 'mynamespace2')
-+ accessPolicies.withOutboundHttp('service.kartverket.no')
-+ accessPolicies.withOutboundPostgres('postgres.kartverket.no', '192.168.1.1')
-+ accessPolicies.withOutboundOracle('oracle.kartverket.no', '192.168.1.2')
-+ accessPolicies.withOutboundSsh('ssh.kartverket.no', '192.168.1.3')
-+ accessPolicies.withOutboundLdaps('ldaps.kartverket.no', '192.168.1.4')
-+ accessPolicies.withInboundSkipApp('theOtherApp', 'mynamespace')
++ argokit.skipJob.withOutboundSkipApp('appJob', 'mynamespace2')
++ argokit.skipJob.withOutboundHttp('service.kartverket.no')
++ argokit.skipJob.withOutboundPostgres('postgres.kartverket.no', '192.168.1.1')
++ argokit.skipJob.withOutboundOracle('oracle.kartverket.no', '192.168.1.2')
++ argokit.skipJob.withOutboundSsh('ssh.kartverket.no', '192.168.1.3')
++ argokit.skipJob.withOutboundLdaps('ldaps.kartverket.no', '192.168.1.4')
++ argokit.skipJob.withInboundSkipApp('theOtherApp', 'mynamespace')

--- a/v2/examples/environment-for-application.jsonnet
+++ b/v2/examples/environment-for-application.jsonnet
@@ -1,11 +1,11 @@
 local argokit = import '../jsonnet/argokit.libsonnet';
 
 argokit.application.new('a-cool-app')
-+ argokit.environment.withVariable('REDIS_PORT', '6379')
-+ argokit.environment.withVariableSecret(
++ argokit.application.withVariable('REDIS_PORT', '6379')
++ argokit.application.withVariableSecret(
     'EMAIL_CLIENTID',
     'email-client-id')
-+ argokit.environment.withVariableSecret(
++ argokit.application.withVariableSecret(
     'SPRING_DATASOURCE_USERNAME',
     'GRUNNBOK_DATASOURCE_USERNAME',
     'grunnbok-database-username')

--- a/v2/examples/ingress.jsonnet
+++ b/v2/examples/ingress.jsonnet
@@ -1,12 +1,12 @@
 
 local argokit = import '../jsonnet/argokit.libsonnet';
 argokit.application.new('testapp')
-+argokit.ingress.forHostnames(import 'ingress/database-ingress')
-+argokit.ingress.forHostnames([
++argokit.application.forHostnames(import 'ingress/database-ingress')
++argokit.application.forHostnames([
   import 'ingress/api-ingress',
   "argokit-frontend-dev.devserver.kartverket-intern.cloud"]
 )
-+argokit.ingress.forHostnames(
++argokit.application.forHostnames(
   [
     "grunnbok.atkv3-prod.kartverket-intern.cloud",
     {

--- a/v2/examples/replicas-static.jsonnet
+++ b/v2/examples/replicas-static.jsonnet
@@ -1,4 +1,4 @@
 local argokit = import '../jsonnet/argokit.libsonnet';
 
 argokit.application.new('testapp')
-+ argokit.replicas.withReplicas(4)
++ argokit.application.withReplicas(4)

--- a/v2/examples/replicas-with-memory.jsonnet
+++ b/v2/examples/replicas-with-memory.jsonnet
@@ -1,4 +1,4 @@
 local argokit = import '../jsonnet/argokit.libsonnet';
 
 argokit.application.new('testapp')
-+ argokit.replicas.withReplicas(initial=3, max=8, targetMemoryUtilization=50)
++ argokit.application.withReplicas(initial=3, max=8, targetMemoryUtilization=50)

--- a/v2/examples/replicas.jsonnet
+++ b/v2/examples/replicas.jsonnet
@@ -1,7 +1,7 @@
 local argokit = import '../jsonnet/argokit.libsonnet';
 
 argokit.application.new('testapp')
-+ argokit.replicas.withReplicas(
++ argokit.application.withReplicas(
     initial=3,
     max=6,
     targetCpuUtilization=50)

--- a/v2/jsonnet/argokit.libsonnet
+++ b/v2/jsonnet/argokit.libsonnet
@@ -1,29 +1,31 @@
-local environment = import '../lib/environment.libsonnet';
 local accessPolicies = import '../lib/accessPolicies.libsonnet';
-local replicas = import '../lib/replicas.libsonnet';
+local environment = import '../lib/environment.libsonnet';
 local ingress = import '../lib/ingress.libsonnet';
+local replicas = import '../lib/replicas.libsonnet';
 
 {
-  accessPolicies: accessPolicies,
-  environment: environment,
-  replicas: replicas,
-  ingress: ingress,
   application: {
-    new (name): {
-      apiVersion: 'skiperator.kartverket.no/v1alpha1',
-      kind: 'Application',
-      metadata: {
-        name: name,
-      },
-    }
-  },
+                 new(name): {
+                   apiVersion: 'skiperator.kartverket.no/v1alpha1',
+                   kind: 'Application',
+                   metadata: {
+                     name: name,
+                   },
+                 },
+               }
+               + ingress
+               + replicas
+               + environment
+               + accessPolicies,
   skipJob: {
-    new(name): {
-      apiVersion: 'skiperator.kartverket.no/v1alpha1',
-      kind: 'SKIPJob',
-      metadata: {
-        name: name,
-      },
-    },
-  }
+             new(name): {
+               apiVersion: 'skiperator.kartverket.no/v1alpha1',
+               kind: 'SKIPJob',
+               metadata: {
+                 name: name,
+               },
+             },
+           }
+           + accessPolicies
+           + environment,
 }

--- a/v2/tests/accessPolicies_test.jsonnet
+++ b/v2/tests/accessPolicies_test.jsonnet
@@ -1,13 +1,11 @@
 local argokit = import '../jsonnet/argokit.libsonnet';
 local test = import 'github.com/jsonnet-libs/testonnet/main.libsonnet';
 
-local accessPolicies = argokit.accessPolicies;
-
 test.new(std.thisFile)
 + test.case.new(
   name='Postgres',
   test=test.expect.eqDiff(
-    actual=(argokit.skipJob.new('a-job') + accessPolicies.withOutboundPostgres('database.kartverket.no', '192.168.1.9')).spec,
+    actual=(argokit.skipJob.new('a-job') + argokit.application.withOutboundPostgres('database.kartverket.no', '192.168.1.9')).spec,
     expected={
       accessPolicy: {
         outbound: {
@@ -32,7 +30,7 @@ test.new(std.thisFile)
 + test.case.new(
   name='HTTP for SKIPJob',
   test=test.expect.eqDiff(
-    actual=(argokit.skipJob.new('a-job') + accessPolicies.withOutboundHttp('server.kartverket.no', port=444, portname='https', protocol='TCP')).spec,
+    actual=(argokit.skipJob.new('a-job') + argokit.application.withOutboundHttp('server.kartverket.no', port=444, portname='https', protocol='TCP')).spec,
     expected={
       container: {
         accessPolicy: {
@@ -58,7 +56,7 @@ test.new(std.thisFile)
 + test.case.new(
   name='HTTP for SKIPApp',
   test=test.expect.eqDiff(
-    actual=(argokit.application.new('an-app') + accessPolicies.withOutboundHttp('server.kartverket.no', port=444, portname='https', protocol='TCP')).spec,
+    actual=(argokit.application.new('an-app') + argokit.application.withOutboundHttp('server.kartverket.no', port=444, portname='https', protocol='TCP')).spec,
     expected={
       accessPolicy: {
         outbound: {

--- a/v2/tests/environment_test.jsonnet
+++ b/v2/tests/environment_test.jsonnet
@@ -1,13 +1,11 @@
 local argokit = import '../jsonnet/argokit.libsonnet';
 local test = import 'github.com/jsonnet-libs/testonnet/main.libsonnet';
 
-local environment = argokit.environment;
-
 test.new(std.thisFile)
 + test.case.new(
   name='Standard Variable',
   test=test.expect.eqDiff(
-    actual=(environment.withVariable('variableName', 'variableValue') + environment.withVariable('variableName2', 'variableValue2')).spec,
+    actual=(argokit.application.withVariable('variableName', 'variableValue') + argokit.application.withVariable('variableName2', 'variableValue2')).spec,
     expected={
       env: [
         {
@@ -25,7 +23,7 @@ test.new(std.thisFile)
 + test.case.new(
   name='Standard Secret Variable for job',
   test=test.expect.eqDiff(
-    actual=(argokit.skipJob.new('a-job') + environment.withVariableSecret('variableName', 'secretRef', 'key')).spec,
+    actual=(argokit.skipJob.new('a-job') + argokit.application.withVariableSecret('variableName', 'secretRef', 'key')).spec,
     expected={
       container: {
         env: [
@@ -46,7 +44,7 @@ test.new(std.thisFile)
 + test.case.new(
   name='Standard Secret Variable for job',
   test=test.expect.eqDiff(
-    actual=(argokit.application.new('a-job') + environment.withVariableSecret('variableName', 'secretRef', 'key')).spec,
+    actual=(argokit.application.new('a-job') + argokit.application.withVariableSecret('variableName', 'secretRef', 'key')).spec,
     expected={
       env: [
         {

--- a/v2/tests/ingress_test.jsonnet
+++ b/v2/tests/ingress_test.jsonnet
@@ -1,13 +1,11 @@
 local argokit = import '../jsonnet/argokit.libsonnet';
 local test = import 'github.com/jsonnet-libs/testonnet/main.libsonnet';
 
-local ingress = argokit.ingress;
-
 test.new(std.thisFile)
 + test.case.new(
   name='Single ingress',
   test=test.expect.eqDiff(
-    actual=ingress.forHostnames('hostName.kartverket.no').spec,
+    actual=argokit.application.forHostnames('hostName.kartverket.no').spec,
     expected={
       ingresses: [
         'hostName.kartverket.no',
@@ -18,7 +16,7 @@ test.new(std.thisFile)
 + test.case.new(
   name='Multiple ingresses',
   test=test.expect.eqDiff(
-    actual=ingress.forHostnames(['hostName.kartverket.no', 'hostName2.kartverket.no']).spec,
+    actual=argokit.application.forHostnames(['hostName.kartverket.no', 'hostName2.kartverket.no']).spec,
     expected={
       ingresses: [
         'hostName.kartverket.no',
@@ -30,7 +28,7 @@ test.new(std.thisFile)
 + test.case.new(
   name='Multiple ingresses with objects',
   test=test.expect.eqDiff(
-    actual=ingress.forHostnames([
+    actual=argokit.application.forHostnames([
       'hostName.kartverket.no',
       {
         hostname: 'hostNameWithCustomCert.kartverket.no',

--- a/v2/tests/replicas_test.jsonnet
+++ b/v2/tests/replicas_test.jsonnet
@@ -1,13 +1,11 @@
 local argokit = import '../jsonnet/argokit.libsonnet';
 local test = import 'github.com/jsonnet-libs/testonnet/main.libsonnet';
 
-local replicas= argokit.replicas;
-
 test.new(std.thisFile)
 + test.case.new(
   name='Setup complete replica set',
   test=test.expect.eqDiff(
-    actual=replicas.withReplicas(2, 4, 80, 90).spec,
+    actual=argokit.application.withReplicas(2, 4, 80, 90).spec,
     expected={
       replicas: {
         max: 4,
@@ -21,7 +19,7 @@ test.new(std.thisFile)
 + test.case.new(
   name='Setup replica without targetMemoryUtilization',
   test=test.expect.eqDiff(
-    actual=replicas.withReplicas(2, 4, 50).spec,
+    actual=argokit.application.withReplicas(2, 4, 50).spec,
     expected={
       replicas: {
         max: 4,
@@ -34,7 +32,7 @@ test.new(std.thisFile)
 + test.case.new(
   name='Setup static replica set',
   test=test.expect.eqDiff(
-    actual=replicas.withReplicas(2).spec,
+    actual=argokit.application.withReplicas(2).spec,
     expected={
       replicas: 2,
     },


### PR DESCRIPTION
Skrevet om til å legge funksjoner under applikasjonstype. Usikker på om jeg har plassert funksjonalitet under riktig type, ta en titt på det.

Dette er nåværende struktur:
```
{
  application: {
                 new(name): { ... }
               + ingress
               + replicas
               + environment
               + accessPolicies,
  skipJob: {
             new(name): { ... }
           + accessPolicies
           + environment,
}
```