### PR TITLE
✌️ Argokit V2 using AppAndObjects

### DIFF
--- a/v2/jsonnet/argokit.libsonnet
+++ b/v2/jsonnet/argokit.libsonnet
@@ -1,18 +1,24 @@
 local accessPolicies = import '../lib/accessPolicies.libsonnet';
+local appAndObjects = import '../lib/appAndObjects.libsonnet';
+local hooks = import '../lib/configHooks.libsonnet';
 local environment = import '../lib/environment.libsonnet';
 local ingress = import '../lib/ingress.libsonnet';
-local replicas = import '../lib/replicas.libsonnet';
 local probes = import '../lib/probes.libsonnet';
+local replicas = import '../lib/replicas.libsonnet';
 
 {
   application: {
-                 new (name): {
-                   apiVersion: 'skiperator.kartverket.no/v1alpha1',
-                   kind: 'Application',
-                   metadata: {
-                     name: name,
+                 new(name):
+                   appAndObjects.AppAndObjects {
+                     application: {
+                       apiVersion: 'skiperator.kartverket.no/v1alpha1',
+                       kind: 'Application',
+                       metadata: {
+                         name: name,
+                       },
+                     },
+                     objects:: [],
                    },
-                 },
                }
                + ingress
                + replicas
@@ -21,15 +27,22 @@ local probes = import '../lib/probes.libsonnet';
                + probes,
 
   skipJob: {
-             new (name): {
-               apiVersion: 'skiperator.kartverket.no/v1alpha1',
-               kind: 'SKIPJob',
-               metadata: {
-                 name: name,
+             new(name):
+               appAndObjects.AppAndObjects {
+                 application: {
+                   apiVersion: 'skiperator.kartverket.no/v1alpha1',
+                   kind: 'SKIPJob',
+                   metadata: {
+                     name: name,
+                   },
+                 },
+                 objects:: [],
                },
-             },
+             enableArgokit():
+               hooks.normalizeSkipJob({ isSkipJob: true, isAppAndObjects: false }),
+
            }
            + accessPolicies
            + environment
-           + probes
+           + probes,
 }

--- a/v2/lib/appAndObjects.libsonnet
+++ b/v2/lib/appAndObjects.libsonnet
@@ -1,0 +1,28 @@
+local hooks = import '../lib/configHooks.libsonnet';
+{
+  /**
+   * Template for rendering app and objects manifests.
+   * The config hooks are applied in the final stage of the
+   * evaluation, ensuring correct formatting.
+  */
+  AppAndObjects:: {
+    apiVersion: 'v1',
+    kind: 'List',
+
+    local isSkipJob = self.application.kind == 'SKIPJob',
+
+    local appConfig = {
+      isSkipJob: isSkipJob,
+      isAppAndObjects: true,
+    },
+
+    local result = std.foldl(
+      function(ap, hook) ap + hook(appConfig),
+      [hooks.normalizeSkipJob, hooks.wrapAsApplicationAndObjects],
+      self
+    ),
+
+    items: std.sort([result.application] + result.objects, keyF=function(x) x.metadata.name),
+    spec:: {},
+  },
+}

--- a/v2/lib/configHooks.libsonnet
+++ b/v2/lib/configHooks.libsonnet
@@ -1,0 +1,45 @@
+{
+  /**
+   *   - When conf.isSkipJob is true, it normalizes the structure of spec.
+   *   - Extracts istioSettings, cron, job, and prometheus from spec (if present)
+   *     and lifts them to top-level spec fields.
+   *   - Keeps empty placeholders for these fields inside spec.container to preserve structure.
+   *   - Prunes null/empty fields after reshaping.
+   */
+  normalizeSkipJob(conf)::
+    if conf.isSkipJob then
+      {
+        local s = super.spec,
+        local is = std.get(s, 'istioSettings', default=null, inc_hidden=true),
+        local cr = std.get(s, 'cron', default=null, inc_hidden=true),
+        local j = std.get(s, 'job', default=null, inc_hidden=true),
+        local pr = std.get(s, 'prometheus', default=null, inc_hidden=true),
+
+        spec: std.prune({
+          container+: s {
+            istioSettings:: {},
+            cron:: {},
+            job:: {},
+            prometheus:: {},
+          },
+          istioSettings: is,
+          cron: cr,
+          job: j,
+          prometheus: pr,
+        }),
+      }
+    else {},
+
+  /**
+   * Hook: wrapAsApplicationAndObjects
+   *   - When conf.isAppAndObjects is true, it copies the evaluated spec into application.spec.
+   *   - Ensures the Application CR contains the same configuration as the root spec.
+   */
+  wrapAsApplicationAndObjects(conf)::
+    if conf.isAppAndObjects
+    then {
+      local s = super.spec,
+      application+: { spec+: s },
+    }
+    else {},
+}


### PR DESCRIPTION
## Updating argokit to use the AppAndObjects pattern, also supports "conventional" manifests.

App and objects implementation using config hooks to correct the structure of the manifest on render.
This allows for good compatability without requiring unique implementations for different use-cases.

**The general idea is**
1. Put the spec field in the root object and use this in the object building
2. On evaluation, move/transform the spec object to its correct location and format


### Argokit V2 compatability
| | AppAndObjects | "Normal" |
|---|---|---|
|**Application** |✅ |  ✅ |
|**Skip Job** | ✅ | ⚠️ * |

*requires user to call the `+ enableArgokit()` at the end of the object construction.