### PR TITLE
♻️ fixed test with new appAndObjects structure

### DIFF
--- a/v2/tests/accessPolicies_test.jsonnet
+++ b/v2/tests/accessPolicies_test.jsonnet
@@ -30,7 +30,7 @@ test.new(std.thisFile)
 + test.case.new(
   name='HTTP for SKIPJob',
   test=test.expect.eqDiff(
-    actual=(argokit.skipJob.new('a-job') + argokit.application.withOutboundHttp('server.kartverket.no', port=444, portname='https', protocol='TCP')).spec,
+    actual=(argokit.skipJob.new('a-job') + argokit.application.withOutboundHttp('server.kartverket.no', port=444, portname='https', protocol='TCP')).items[0].spec,
     expected={
       container: {
         accessPolicy: {
@@ -56,7 +56,7 @@ test.new(std.thisFile)
 + test.case.new(
   name='HTTP for SKIPApp',
   test=test.expect.eqDiff(
-    actual=(argokit.application.new('an-app') + argokit.application.withOutboundHttp('server.kartverket.no', port=444, portname='https', protocol='TCP')).spec,
+    actual=(argokit.application.new('an-app') + argokit.application.withOutboundHttp('server.kartverket.no', port=444, portname='https', protocol='TCP')).items[0].spec,
     expected={
       accessPolicy: {
         outbound: {

--- a/v2/tests/environment_test.jsonnet
+++ b/v2/tests/environment_test.jsonnet
@@ -5,7 +5,7 @@ test.new(std.thisFile)
 + test.case.new(
   name='Standard Variable',
   test=test.expect.eqDiff(
-    actual=(argokit.application.withVariable('variableName', 'variableValue') + argokit.application.withVariable('variableName2', 'variableValue2')).spec,
+    actual=(argokit.application.new('an-app')+ argokit.application.withVariable('variableName', 'variableValue') + argokit.application.withVariable('variableName2', 'variableValue2')).spec,
     expected={
       env: [
         {
@@ -23,7 +23,7 @@ test.new(std.thisFile)
 + test.case.new(
   name='Standard Secret Variable for job',
   test=test.expect.eqDiff(
-    actual=(argokit.skipJob.new('a-job') + argokit.application.withVariableSecret('variableName', 'secretRef', 'key')).spec,
+    actual=(argokit.skipJob.new('a-job') + argokit.application.withVariableSecret('variableName', 'secretRef', 'key')).items[0].spec,
     expected={
       container: {
         env: [
@@ -44,7 +44,7 @@ test.new(std.thisFile)
 + test.case.new(
   name='Standard Secret Variable for job',
   test=test.expect.eqDiff(
-    actual=(argokit.application.new('a-job') + argokit.application.withVariableSecret('variableName', 'secretRef', 'key')).spec,
+    actual=(argokit.application.new('a-job') + argokit.application.withVariableSecret('variableName', 'secretRef', 'key')).items[0].spec,
     expected={
       env: [
         {

--- a/v2/tests/probes_test.jsonnet
+++ b/v2/tests/probes_test.jsonnet
@@ -5,7 +5,7 @@ test.new(std.thisFile)
 + test.case.new(
   name='readiness probe',
   test=test.expect.eqDiff(
-    actual=(argokit.skipJob.new('a-job') + argokit.application.withLiveness(argokit.application.probe(path='/health', port=8080, failureThreshold=5, timeout=0, initialDelay=5))).spec,
+    actual=(argokit.skipJob.new('a-job') + argokit.application.withLiveness(argokit.application.probe(path='/health', port=8080, failureThreshold=5, timeout=0, initialDelay=5))).items[0].spec,
     expected={
       container: {
         liveness: {
@@ -22,7 +22,7 @@ test.new(std.thisFile)
 + test.case.new(
   name='liveness probe',
   test=test.expect.eqDiff(
-    actual=(argokit.application.new('application') + argokit.application.withReadiness(argokit.application.probe(path='/health', port=8080))).spec,
+    actual=(argokit.application.new('application') + argokit.application.withReadiness(argokit.application.probe(path='/health', port=8080))).items[0].spec,
     expected={
       readiness: {
         failureThreshold: 3,
@@ -37,7 +37,7 @@ test.new(std.thisFile)
 + test.case.new(
   name='startup probe',
   test=test.expect.eqDiff(
-    actual=(argokit.application.new('application') + argokit.application.withStartup(argokit.application.probe(path='/health', port=8080))).spec,
+    actual=(argokit.application.new('application') + argokit.application.withStartup(argokit.application.probe(path='/health', port=8080))).items[0].spec,
     expected={
       startup: {
         failureThreshold: 3,


### PR DESCRIPTION
This pull request updates several tests in the `v2/tests` suite to consistently access the `spec` property from the first item in the `.items` array, rather than directly from the object. This change ensures that tests correctly reflect the structure of objects returned by the `argokit` API, improving reliability and consistency across different test cases.

**Access pattern updates in tests:**

_Environment variable and secret tests:_
* Updated environment variable and secret tests to access `.items[0].spec` instead of `.spec` for both jobs and applications in `environment_test.jsonnet`. [[1]](diffhunk://#diff-93fa6bf16a832edd0cc09fc93604b6c4c5cc6a9ebe84b5536ab3e8452ecf1fd5L8-R8) [[2]](diffhunk://#diff-93fa6bf16a832edd0cc09fc93604b6c4c5cc6a9ebe84b5536ab3e8452ecf1fd5L26-R26) [[3]](diffhunk://#diff-93fa6bf16a832edd0cc09fc93604b6c4c5cc6a9ebe84b5536ab3e8452ecf1fd5L47-R47)

_Probe tests:_
* Changed liveness, readiness, and startup probe tests to use `.items[0].spec` for jobs and applications in `probes_test.jsonnet`. [[1]](diffhunk://#diff-99b3a9ca26ba6e974833987f8ece1b9ee54ffcead4f8892ce6f190a7fd568b1dL8-R8) [[2]](diffhunk://#diff-99b3a9ca26ba6e974833987f8ece1b9ee54ffcead4f8892ce6f190a7fd568b1dL25-R25) [[3]](diffhunk://#diff-99b3a9ca26ba6e974833987f8ece1b9ee54ffcead4f8892ce6f190a7fd568b1dL40-R40)

_Access policy tests:_
* Modified outbound HTTP access policy tests to use `.items[0].spec` for jobs and applications in `accessPolicies_test.jsonnet`. [[1]](diffhunk://#diff-826fef4a173517a43c8c8dc63defa8205f03adafd8982b6f2b5ddac5a3b47531L33-R33) [[2]](diffhunk://#diff-826fef4a173517a43c8c8dc63defa8205f03adafd8982b6f2b5ddac5a3b47531L59-R59)The test suite needs to adhere to the new argoKit appAndObjects structure in v2.