### PR TITLE
🦺 add validation functions

### DIFF
--- a/v2/internal/validation.libsonnet
+++ b/v2/internal/validation.libsonnet
@@ -1,0 +1,40 @@
+{
+  // call this method in your method definition
+  // to validate input!
+  // !important! must be able to render in order to validate
+  compose(objs): std.prune(
+    {
+      valid: std.foldl(
+        function(acc, o) acc + o,
+        objs,
+        {}
+      ),
+    }
+  ),
+
+  // support normal expressions
+  require(cond, msg):
+    if cond then {} else error msg
+  ,
+
+  // validate string
+  string(value, label='value', allowEmpty=true):
+    if std.isString(value) then
+      if !allowEmpty && value == '' then error label + ' must be non-empty string'
+      else {}
+    else error label + ' must be type string',
+
+  // validate number
+  number(value, label='value'):
+    if std.isNumber(value) then {}
+    else error label + ' must be a number',
+
+  // validate array
+  array(value, allowEmpty=true):
+    if std.type(value) == 'array'
+    then
+      if !allowEmpty && std.length(value) == 0
+      then error 'array must not be empty'
+      else {}
+    else error 'must be array',
+}

--- a/v2/internal/validation.libsonnet
+++ b/v2/internal/validation.libsonnet
@@ -1,17 +1,4 @@
 {
-  // call this method in your method definition
-  // to validate input!
-  // !important! must be able to render in order to validate
-  compose(objs): std.prune(
-    {
-      valid: std.foldl(
-        function(acc, o) acc + o,
-        objs,
-        {}
-      ),
-    }
-  ),
-
   // support normal expressions
   require(cond, msg):
     if cond then {} else error msg
@@ -30,11 +17,15 @@
     else error label + ' must be a number',
 
   // validate array
-  array(value, allowEmpty=true):
-    if std.type(value) == 'array'
+  array(value, label, allowEmpty=true):
+    if std.isArray(value)
     then
       if !allowEmpty && std.length(value) == 0
       then error 'array must not be empty'
       else {}
     else error 'must be array',
+
+  boolean(value, label):
+    if std.isBoolean(value) then {}
+    else error label + ' must be type boolean',
 }

--- a/v2/jsonnet/argokit.libsonnet
+++ b/v2/jsonnet/argokit.libsonnet
@@ -1,3 +1,4 @@
+local v = import '../internal/validation.libsonnet';
 local accessPolicies = import '../lib/accessPolicies.libsonnet';
 local appAndObjects = import '../lib/appAndObjects.libsonnet';
 local hooks = import '../lib/configHooks.libsonnet';
@@ -5,10 +6,12 @@ local environment = import '../lib/environment.libsonnet';
 local ingress = import '../lib/ingress.libsonnet';
 local probes = import '../lib/probes.libsonnet';
 local replicas = import '../lib/replicas.libsonnet';
-
 {
   application: {
                  new(name):
+                   v.compose([
+                     v.string(name, 'name', false),
+                   ]) +
                    appAndObjects.AppAndObjects {
                      application: {
                        apiVersion: 'skiperator.kartverket.no/v1alpha1',
@@ -28,6 +31,9 @@ local replicas = import '../lib/replicas.libsonnet';
 
   skipJob: {
              new(name):
+               v.compose([
+                 v.string(name, 'name', false),
+               ]) +
                appAndObjects.AppAndObjects {
                  application: {
                    apiVersion: 'skiperator.kartverket.no/v1alpha1',

--- a/v2/jsonnet/argokit.libsonnet
+++ b/v2/jsonnet/argokit.libsonnet
@@ -9,9 +9,7 @@ local replicas = import '../lib/replicas.libsonnet';
 {
   application: {
                  new(name):
-                   v.compose([
-                     v.string(name, 'name', false),
-                   ]) +
+                   v.string(name, 'name', allowEmpty=false) +
                    appAndObjects.AppAndObjects {
                      application: {
                        apiVersion: 'skiperator.kartverket.no/v1alpha1',
@@ -31,9 +29,7 @@ local replicas = import '../lib/replicas.libsonnet';
 
   skipJob: {
              new(name):
-               v.compose([
-                 v.string(name, 'name', false),
-               ]) +
+               v.string(name, 'name', allowEmpty=false) +
                appAndObjects.AppAndObjects {
                  application: {
                    apiVersion: 'skiperator.kartverket.no/v1alpha1',


### PR DESCRIPTION
## Added internal validation lib

Of course using **foldl** we can get a clean interface to use in our functions.
See it used in `v2/jsonnet/argokit.libsonnet`

**Built in validation functions for:**
- string
- array
- number

**Usage**
```jsonnet 
local v = import '../internal/validation.libsonnet';


new(name):
 v.compose([
   v.string(name, 'name', false),
   v.require('foo' == 'bar', 'jsonnet equlas not working'),

 ]) +
 appAndObjects.AppAndObjects {
```