### PR TITLE
Cleanup custom skipjob handling in functions

### DIFF
--- a/v2/README.md
+++ b/v2/README.md
@@ -12,16 +12,16 @@ questions, please reach out to the #gen-argocd or #spire-kartverket-devex-sparri
 ## Installation
 
 Assuming you have followed the [Getting Started](https://kartverket.atlassian.net/wiki/spaces/SKIPDOK/pages/554827836/Komme+i+gang+med+Argo+CD)
-guide, you can use ArgoKit in your apps-repo. 
+guide, you can use ArgoKit in your apps-repo.
 
-First you need to install jsonnet bundler. This is done by running `brew install jsonnet-bundler` or download the 
+First you need to install jsonnet bundler. This is done by running `brew install jsonnet-bundler` or download the
 [binary release](https://github.com/jsonnet-bundler/jsonnet-bundler).
-Next run `jb init`, and finally run `jb install github.com/kartverket/argokit@main`. If you want 
+Next run `jb init`, and finally run `jb install github.com/kartverket/argokit@main`. If you want
 to stay on a specific version use `jb install github.com/kartverket/argokit@2.0.0`
 
 Remember to add `vendor/` to .gitignore
 
-### Git submodules 
+### Git submodules
 Alternatively you can use submodules if you prefer it over jsonnet bundler (We recommend jsonnet bundler).
 Include the ArgoKit library by running the following command:
 
@@ -74,7 +74,7 @@ The following examples are available at [our github](https://github.com/kartverk
 | `argokit.application.new()` | Creates a Skiperator application, using the appAndObjects convention (this is default).| See above                                                                                  |
 | `argokit.skipJob.new()` | Creates a Skiperator job, using the appAndObjects convention. | [examples/accessPolicies-for-job.jsonnet](https://github.com/kartverket/argokit/blob/main/v2/examples/accessPolicies-for-job.jsonnet)|
 ### argoKit's Replicas API
-**NOTE!** It is not recommended to run with less than 2 replicas... 
+**NOTE!** It is not recommended to run with less than 2 replicas...
 | Template                                | Description                                                     | Example                                                                                    |
 |-----------------------------------------|-----------------------------------------------------------------|--------------------------------------------------------------------------------------------|
 | `argokit.application.withReplicas`   | Create replicas for an application with sensible defaults  | [examples/replicas.jsonnet](https://github.com/kartverket/argokit/blob/main/v2/examples/replicas.jsonnet)               |
@@ -86,9 +86,9 @@ The following examples are available at [our github](https://github.com/kartverk
 
 | Template                                              | Description                                                    | Example                                                                  |
 |-------------------------------------------------------|----------------------------------------------------------------|--------------------------------------------------------------------------|
-| `argokit.[application\|skipJOB].withVariable`         | Creates environment variables for an app                       | [examples/envVariables.jsonnet](https://github.com/kartverket/argokit/blob/main/v2/examples/envVariables.jsonnet) |
-| `argokit.[application\|skipJOB].withVariableSecret`   | Creates environment variable from a secret                     | [examples/envVariables.jsonnet](https://github.com/kartverket/argokit/blob/main/v2/examples/envVariables.jsonnet) |
-| `argokit.[application\|skipJOB].withVariableSecret`   | Creates environment variable from a secret for a Job container | [examples/envVariables.jsonnet](https://github.com/kartverket/argokit/blob/main/v2/examples/envVariables.jsonnet) |
+| `argokit.[application\|skipJOB].withVariable`         | Creates environment variables for an app                       | [examples/environment-for-application.jsonnet](https://github.com/kartverket/argokit/blob/main/v2/examples/environment-for-application.jsonnet) |
+| `argokit.[application\|skipJOB].withVariableSecret`   | Creates environment variable from a secret                     | [examples/environment-for-application.jsonnet](https://github.com/kartverket/argokit/blob/main/v2/examples/environment-for-application.jsonnet) |
+| `argokit.[application\|skipJOB].withVariableSecret`   | Creates environment variable from a secret for a Job container | [examples/environment-for-application.jsonnet](https://github.com/kartverket/argokit/blob/main/v2/examples/environment-for-application.jsonnet) |
 
 ---
 ### argoKit's Ingress API
@@ -100,7 +100,7 @@ The following examples are available at [our github](https://github.com/kartverk
 
 ### argoKit's accessPolicies API
 
-You can define what external services (hosts/IPs) and internal SKIP applications your app or job may communicate with.  
+You can define what external services (hosts/IPs) and internal SKIP applications your app or job may communicate with.
 All functions work for both applications and skipJobs: `argokit.application.*` or `argokit.skipJob.*`.
 
 | Template                                                          | Description                                                                 | Example |

--- a/v2/examples/envVariables.jsonnet
+++ b/v2/examples/envVariables.jsonnet
@@ -1,7 +1,0 @@
-local argokit = import '../../../argokit/jsonnet/argokit.libsonnet';
-
-argokit.Application('a-cool-app') 
-+argokit.Env.variable('REDIS_PORT','6379')
-+argokit.Env.variableSecret('EMAIL_CLIENTID','email-client-id')
-+argokit.Env.variableSecretJob('SLACK_OAUTH_TOKEN','slack-oauth-token')
-+argokit.Env.variableSecret('SPRING_DATASOURCE_USERNAME', 'GRUNNBOK_DATASOURCE_USERNAME', 'grunnbok-database-username')

--- a/v2/lib/accessPolicies.libsonnet
+++ b/v2/lib/accessPolicies.libsonnet
@@ -1,5 +1,3 @@
-local util = import 'util.libsonnet';
-
 {
   local rules(appname, namespace) = {
     rules+: [
@@ -125,7 +123,7 @@ local util = import 'util.libsonnet';
           },
         },
       },
-      spec+: if util.isSKIPJob(self.kind) then { container+: httpPolicy(portname, port, protocol) } else httpPolicy(portname, port, protocol),
+      spec+: httpPolicy(portname, port, protocol),
     },
 
   /**
@@ -142,7 +140,7 @@ local util = import 'util.libsonnet';
           } + rules(appname, namespace),
         },
       },
-      spec+: if util.isSKIPJob(self.kind) then { container+: policy(appname, namespace) } else policy(appname, namespace),
+      spec+: policy(appname, namespace),
     },
 
   /**

--- a/v2/lib/environment.libsonnet
+++ b/v2/lib/environment.libsonnet
@@ -1,4 +1,3 @@
-local util = import 'util.libsonnet';
 {
   /**
   Creates an environment variable with a static value.
@@ -23,7 +22,7 @@ local util = import 'util.libsonnet';
         { secret: secretName },
       ],
     },
-    spec+: if util.isSKIPJob(self.kind) then { container+: variableSecret(secretName) } else variableSecret(secretName),
+    spec+: variableSecret(secretName),
   },
 
   /**
@@ -47,6 +46,6 @@ local util = import 'util.libsonnet';
         },
       ],
     },
-    spec+: if util.isSKIPJob(self.kind) then { container+: variableSecret(name, secretRef, key) } else variableSecret(name, secretRef, key),
+    spec+: variableSecret(name, secretRef, key),
   },
 }

--- a/v2/lib/probes.libsonnet
+++ b/v2/lib/probes.libsonnet
@@ -1,12 +1,10 @@
-local util = import 'util.libsonnet';
-
 {
   /**
   Liveness probes define a resource that returns 200 OK when the app is running as intended.
   Returning a non-200 code will make kubernetes restart the app.
   	*/
   withLiveness(probe):: {
-    spec+: if util.isSKIPJob(self.kind) then { container+: { liveness: probe } } else { liveness: probe },
+    spec+: { liveness: probe },
   },
 
   /**
@@ -14,7 +12,7 @@ local util = import 'util.libsonnet';
    until the resource returns 200 OK before 	marking the pod as Running and progressing with the deployment strategy.
    	*/
   withReadiness(probe):: {
-    spec+: if util.isSKIPJob(self.kind) then { container+: { readiness: probe } } else { readiness: probe },
+    spec+: { readiness: probe },
   },
   /**
   Kubernetes uses startup probes to know when a container application has started. If such a probe is configured, it
@@ -23,7 +21,7 @@ local util = import 'util.libsonnet';
   killed by Kubernetes before they are up and running.
   */
   withStartup(probe):: {
-    spec+: if util.isSKIPJob(self.kind) then { container+: { startup: probe } } else { startup: probe },
+    spec+: { startup: probe },
   },
 
   /**

--- a/v2/lib/util.libsonnet
+++ b/v2/lib/util.libsonnet
@@ -1,3 +1,0 @@
-{
-  isSKIPJob(kindOfParent):: kindOfParent == 'SKIPJob',
-}


### PR DESCRIPTION
# 🧹 Some cleanup of unnecessary skipJob checks

The isSkipJob utils are made obsolete by the new app and objects structure, and can therefore be removed.

**Note**
There were also a example in v2 using the old environment api, so i removed it from the v2 examples and readme.