### PR TITLE
🎲 implement v2 role binding

### DIFF
--- a/v2/examples/roles.jsonnet
+++ b/v2/examples/roles.jsonnet
@@ -1,0 +1,14 @@
+local argokit = import '../jsonnet/argokit.libsonnet';
+
+
+[
+  argokit.roles.newRoleBinding()
+  + argokit.roles.withNamespaceAdminGroup('testgroup'),
+
+  argokit.roles.newRoleBinding()
+  + argokit.roles.withUsers([
+    'example1@kartverket.no',
+    'example2@kartverket.no',
+    'example3@kartverket.no',
+  ]),
+]

--- a/v2/jsonnet/argokit.libsonnet
+++ b/v2/jsonnet/argokit.libsonnet
@@ -7,8 +7,10 @@ local environment = import '../lib/environment.libsonnet';
 local ingress = import '../lib/ingress.libsonnet';
 local probes = import '../lib/probes.libsonnet';
 local replicas = import '../lib/replicas.libsonnet';
+local roles = import '../lib/roles.libsonnet';
 local routing = import '../lib/routing.libsonnet';
 {
+  roles: roles,
   routing: routing,
   application: {
                  new(name):

--- a/v2/lib/roles.libsonnet
+++ b/v2/lib/roles.libsonnet
@@ -1,0 +1,56 @@
+local v = import '../internal/validation.libsonnet';
+
+{
+  newRoleBinding():: {
+    apiVersion: 'rbac.authorization.k8s.io/v1',
+    kind: 'RoleBinding',
+    metadata: {
+      name: 'team-admin',
+      annotations: {
+        description: 'Binds cluster-admin to every member and relevant SAs within a product. Allows all subjects to have full rights within their namespace. Usually reserved for dev/sandbox.',
+      },
+    },
+    subjects: [],
+    roleRef: {
+      kind: 'ClusterRole',
+      name: 'cluster-admin',
+      apiGroup: 'rbac.authorization.k8s.io',
+    },
+  },
+
+  withUsers(users)::
+    v.array(users, 'users') +
+    {
+      subjects+: [
+        {
+          apiGroup: 'rbac.authorization.k8s.io',
+          kind: 'User',
+          name: u,
+        }
+        for u in users
+      ],
+      metadata+: {
+        name: 'team-admin',
+        annotations: {
+          description: 'Binds cluster-admin to every member and relevant SAs within a product. Allows all subjects to have full rights within their namespace. Usually reserved for dev/sandbox.',
+        },
+      },
+    },
+  withNamespaceAdminGroup(groupName)::
+    v.string(groupName, 'groupName') +
+    {
+      subjects+: [
+        {
+          apiGroup: 'rbac.authorization.k8s.io',
+          kind: 'Group',
+          name: groupName,
+        },
+      ],
+      metadata+: {
+        name: 'namespace-admin',
+        annotations: {
+          description: 'Binds cluster-admin to the team AD/Google Group. Allows all subjects to have full rights within their namespace. Reserved for dev/sandbox.',
+        },
+      },
+    },
+}

--- a/v2/tests/roles_test.jsonnet
+++ b/v2/tests/roles_test.jsonnet
@@ -1,0 +1,76 @@
+local argokit = import '../jsonnet/argokit.libsonnet';
+local test = import 'github.com/jsonnet-libs/testonnet/main.libsonnet';
+
+local label = 'rolebinding ';
+
+// test data
+local testUsers = [
+  'example1@kartverket.no',
+  'example2@kartverket.no',
+  'example3@kartverket.no',
+];
+local testGroupName = 'test-group';
+
+
+// build test objects
+local rbTeam =
+  argokit.roles.newRoleBinding()
+  + argokit.roles.withUsers(testUsers);
+
+local rbAdmin =
+  argokit.roles.newRoleBinding()
+  + argokit.roles.withNamespaceAdminGroup(testGroupName);
+
+
+// test cases for resourcebinding team admin
+
+test.new(std.thisFile)
++ test.case.new(
+  name=label + 'metadata name is team admin',
+  test=test.expect.eqDiff(
+    actual=rbTeam.metadata.name,
+    expected='team-admin',
+  )
+)
+
++ test.case.new(
+  name=label + 'subjects kind is User',
+  test=test.expect.eqDiff(
+    actual=std.all(std.map(function(x) x.kind == 'User', rbTeam.subjects)),
+    expected=true,
+  )
+)
+
++ test.case.new(
+  name=label + 'subject names match',
+  test=test.expect.eqDiff(
+    actual=std.map(function(x) x.name, rbTeam.subjects),
+    expected=testUsers,
+  )
+)
+
+// test cases for resourcebinding namespace admin group
+
++ test.case.new(
+  name=label + 'metadata name is namespace admin',
+  test=test.expect.eqDiff(
+    actual=rbAdmin.metadata.name,
+    expected='namespace-admin',
+  )
+)
+
++ test.case.new(
+  name=label + 'subjects kind is Group',
+  test=test.expect.eqDiff(
+    actual=std.all(std.map(function(x) x.kind == 'Group', rbAdmin.subjects)),
+    expected=true,
+  )
+)
+
++ test.case.new(
+  name=label + 'group name is correct',
+  test=test.expect.eqDiff(
+    actual=std.map(function(x) x.name, rbAdmin.subjects),
+    expected=[testGroupName],
+  )
+)


### PR DESCRIPTION
## V2 role binding

Implemented using a constructor pattern with `new()`, 
then extending the object with two `.with...` methods for 
team admin and namespace admin group.

Is this a good approach since both variants of the role binding is 
the same resource Kind,  or should we stick with separate functions to 
define them?
