### PR TITLE
BUGFIX: Set deprecated label to be string. Bool not allowed

### DIFF
--- a/v2/internal/utils.libsonnet
+++ b/v2/internal/utils.libsonnet
@@ -8,7 +8,7 @@ local version = import '../../version.libsonnet';
           'skip.kartverket.no/argokit-git-ref': version.sha,
           'skip.kartverket.no/argokit-tag': version.tag,
           'skip.kartverket.no/argokit-flavor': flavor,
-          [if versionDeprecated != null then 'skip.kartverket.no/argokit-deprecated-version']: versionDeprecated,
+          [if versionDeprecated != null then 'skip.kartverket.no/argokit-deprecated-version']: std.toString(versionDeprecated),
         },
       },
     },

--- a/v2/tests/routing_test.jsonnet
+++ b/v2/tests/routing_test.jsonnet
@@ -83,3 +83,15 @@ test.new(std.thisFile)
     expected=false
   ),
 )
++ test.case.new(
+  name='Routing has deprecated label when marked as deprecated',
+  test=(
+    local deprecatedRouting = 
+      argokit.routing.new('myapp-routing', 'myhostname')
+      + utils.withArgokitVersionLabel(versionDeprecated=true, flavor='v2');
+    test.expect.eq(
+      actual=deprecatedRouting.metadata.labels['skip.kartverket.no/argokit-deprecated-version'],
+      expected='true'
+    )
+  ),
+)


### PR DESCRIPTION
## Description 📝
Based on error it seems that labels can't be a boolean. Seems when i added the labels i didnt test with deprecated components. Hopefully this fixes it

`Failed to compare desired state to live state: failed to calculate diff: error calculating structured merge diff: error building typed value from config resource: .metadata.labels.skip.kartverket.no/argokit-deprecated-version: expected string, got &value.valueUnstructured{Value:true}`

## Motivation and Context 💡
Fix bug in main for argokit

## How Has This Been Tested? 🧪
TODO

## Checklist: ✅
- [x] My code follows the code style of this project. 💅
- [ ] My changes do not break the existing tests 🧪
- [ ] I have updated the tests accordingly ➕ 