### PR TITLE
Use octo-sts token to push to main

### DIFF
--- a/.github/chainguard/version_updater.sts.yaml
+++ b/.github/chainguard/version_updater.sts.yaml
@@ -1,0 +1,5 @@
+issuer: https://token.actions.githubusercontent.com
+subject_pattern: repo:kartverket/argokit:ref:refs/heads/main
+
+permissions:
+  contents: write

--- a/.github/workflows/generate-git-version.yaml
+++ b/.github/workflows/generate-git-version.yaml
@@ -17,10 +17,17 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - uses: octo-sts/action@f603d3be9d8dd9871a265776e625a27b00effe05 # v1.1.1
+        id: octo-sts
+        with:
+          scope: kartverket/argokit
+          identity: version_updater
+
       - name: Checkout repository
         uses: actions/checkout@v6
         with:
           fetch-depth: 0  # Fetch all history for tags
+          token: ${{ steps.octo-sts.outputs.token }}
 
       - name: Generate version
         run: ./generate-version.sh


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description 📝
The branch protection rule doesn't allow us to bypass commit using the github action builtin token. Using octo-sts solves this, and we can also limit access to only modify the version.libsonent file

## Motivation and Context 💡
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested? 🧪
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate): 📸

## Types of changes 🔄
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue) 🐛
- [ ] New feature (non-breaking change which adds functionality) ✨
- [ ] Breaking change (fix or feature that would cause existing functionality to change) 💥

## Checklist: ✅
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project. 💅
- [ ] My changes do not break the existing tests 🧪
- [ ] I have updated the tests accordingly ➕ 
- [ ] My change requires a change to the documentation. 📚
- [ ] I have updated the documentation accordingly. 📝

## Also fixed: 🤩
<!---If this pull request also fixes something else that is not related to the main description. -->
<!---For example: you found a bug and it was a quick fix. It might be other stuff as well :) -->

## Questions: ❓
<!--- If you have some questions, put them under here pointwise. -->