### PR TITLE
Feaure/add destinationrule

### DIFF
--- a/generate-version.sh
+++ b/generate-version.sh
@@ -33,4 +33,3 @@ cat > version.libsonnet <<EOF
 EOF
 
 echo "Generated version.libsonnet with sha ${SHA} and tag ${TAG}"
-

--- a/v2/api-reference.md
+++ b/v2/api-reference.md
@@ -464,6 +464,19 @@ Monter en Persistent Volume Claim (PVC) på angitt sti.
 
 **Eksempel:** [examples/mounts.jsonnet](https://github.com/kartverket/argokit/blob/main/v2/examples/mounts.jsonnet)
 
+## ArgoKit's DestinationRule API
+
+### `argokit.appAndObjects.application.withStickySession()`
+Oppretter en Istio DestinationRule for sticky sessions ved bruk av konsistent hash-basert lastbalansering. Dette muliggjør sesjonspersistens ved å rute forespørsler fra samme klient til samme pod.
+
+|navn|type|obligatorisk|standardverdi|beskrivelse|
+|-|-|-|-|-|
+|`cookieName`|`string`|`false`|'ISTIO-STICKY'|navn på cookie som brukes for sticky sessions|
+|`cookiePath`|`string`|`false`|'/'|sti for cookien|
+|`cookieTtl`|`string`|`false`|'0'|TTL for cookien ('0' betyr sesjonscookie)|
+
+**Eksempel:** [examples/stickySession.jsonnet](https://github.com/kartverket/argokit/blob/main/v2/examples/stickySession.jsonnet)
+
 ### `argokit.appAndObjects.application.withEmptyDirAsMount()`
 Monter en emptyDir-volum på angitt sti.
 

--- a/v2/api-reference.md
+++ b/v2/api-reference.md
@@ -472,7 +472,7 @@ Oppretter en Istio DestinationRule for sticky sessions ved bruk av konsistent ha
 |navn|type|obligatorisk|standardverdi|beskrivelse|
 |-|-|-|-|-|
 |`cookieName`|`string`|`false`|'ISTIO-STICKY'|navn på cookie som brukes for sticky sessions|
-|`cookiePath`|`string`|`false`|'/'|sti for cookien|
+|`cookiePath`|`string`|`false`|`null`|sti for cookien (valgfritt - utelates hvis ikke angitt)|
 |`cookieTtl`|`string`|`false`|'0'|TTL for cookien ('0' betyr sesjonscookie)|
 
 **Eksempel:** [examples/stickySession.jsonnet](https://github.com/kartverket/argokit/blob/main/v2/examples/stickySession.jsonnet)

--- a/v2/api-reference.md
+++ b/v2/api-reference.md
@@ -477,6 +477,30 @@ Oppretter en Istio DestinationRule for sticky sessions ved bruk av konsistent ha
 
 **Eksempel:** [examples/stickySession.jsonnet](https://github.com/kartverket/argokit/blob/main/v2/examples/stickySession.jsonnet)
 
+### `argokit.appAndObjects.application.withPortLevelTls()`
+Oppretter en Istio DestinationRule for port-nivå TLS-konfigurasjon. Dette muliggjør TLS for spesifikke porter på en tjeneste.
+
+|navn|type|obligatorisk|standardverdi|beskrivelse|
+|-|-|-|-|-|
+|`host`|`string`|`true`| - |mål-vert (kan være enkel hostname eller formatert som 'pod.service')|
+|`port`|`number`|`false`|443|portnummer for TLS-konfigurasjon|
+|`tlsMode`|`string`|`false`|'SIMPLE'|TLS-modus (ISTIO_MUTUAL, SIMPLE, MUTUAL, DISABLE)|
+|`name`|`string`|`false`|`null`|egendefinert navn for DestinationRule (standard: applikasjonsnavn)|
+
+**Eksempel:** [examples/portLevelTls.jsonnet](https://github.com/kartverket/argokit/blob/main/v2/examples/portLevelTls.jsonnet)
+
+### `argokit.appAndObjects.application.withTrafficPolicyTls()`
+Oppretter en Istio DestinationRule med traffic policy TLS-konfigurasjon. Dette konfigurerer TLS-innstillinger for utgående trafikk til eksterne tjenester med SNI-støtte.
+
+|navn|type|obligatorisk|standardverdi|beskrivelse|
+|-|-|-|-|-|
+|`name`|`string`|`true`| - |navn på DestinationRule|
+|`host`|`string`|`true`| - |ekstern vert/host|
+|`tlsMode`|`string`|`false`|'SIMPLE'|TLS-modus (SIMPLE, MUTUAL, ISTIO_MUTUAL, DISABLE)|
+|`sni`|`string`|`false`|`null`|SNI-streng som presenteres til serveren under TLS-handshake|
+
+**Eksempel:** [examples/trafficPolicyTls.jsonnet](https://github.com/kartverket/argokit/blob/main/v2/examples/trafficPolicyTls.jsonnet)
+
 ### `argokit.appAndObjects.application.withEmptyDirAsMount()`
 Monter en emptyDir-volum på angitt sti.
 

--- a/v2/examples/portLevelTls.jsonnet
+++ b/v2/examples/portLevelTls.jsonnet
@@ -1,0 +1,9 @@
+local argokit = import '../jsonnet/argokit.libsonnet';
+local application = argokit.appAndObjects.application;
+
+application.new('my-service', 'myapp:1.0.0', 8080)
++ application.withPortLevelTls(
+  host='my-pod.my-headless-svc',
+  port=7800,
+  tlsMode='ISTIO_MUTUAL'
+)

--- a/v2/examples/stickySession.jsonnet
+++ b/v2/examples/stickySession.jsonnet
@@ -1,0 +1,13 @@
+local argokit = import '../jsonnet/argokit.libsonnet';
+local application = argokit.appAndObjects.application;
+
+// Example: Application with sticky sessions enabled
+// This creates an Istio DestinationRule that ensures requests from the same client
+// are routed to the same pod using cookie-based consistent hashing
+
+application.new('my-app', 'my-image:1.0', 8080)
++ application.withStickySession()
+
+// With custom cookie settings:
+// application.new('my-app', 'my-image:1.0', 8080)
+// + application.withStickySession(cookieName='MY-SESSION', cookiePath='/api', cookieTtl='3600s')

--- a/v2/examples/stickySession.jsonnet
+++ b/v2/examples/stickySession.jsonnet
@@ -1,13 +1,17 @@
 local argokit = import '../jsonnet/argokit.libsonnet';
 local application = argokit.appAndObjects.application;
 
-// Example: Application with sticky sessions enabled
+// Example: Application with sticky sessions enabled (default settings, no path)
 // This creates an Istio DestinationRule that ensures requests from the same client
 // are routed to the same pod using cookie-based consistent hashing
 
 application.new('my-app', 'my-image:1.0', 8080)
 + application.withStickySession()
 
-// With custom cookie settings:
+// With custom cookie settings (like the aal-register example):
+// application.new('my-app', 'my-image:1.0', 8080)
+// + application.withStickySession(cookieName='MY-SESSION', cookieTtl='1800s')
+
+// With path specified:
 // application.new('my-app', 'my-image:1.0', 8080)
 // + application.withStickySession(cookieName='MY-SESSION', cookiePath='/api', cookieTtl='3600s')

--- a/v2/examples/trafficPolicyTls.jsonnet
+++ b/v2/examples/trafficPolicyTls.jsonnet
@@ -1,0 +1,10 @@
+local argokit = import '../jsonnet/argokit.libsonnet';
+local application = argokit.appAndObjects.application;
+
+application.new('my-app', 'myapp:1.0.0', 8080)
++ application.withTrafficPolicyTls(
+  name='jenkins-matrikkel-no',
+  host='jenkins.matrikkel.no',
+  tlsMode='SIMPLE',
+  sni='jenkins.matrikkel.no'
+)

--- a/v2/lib/appAndObjects/appAndObjects.libsonnet
+++ b/v2/lib/appAndObjects/appAndObjects.libsonnet
@@ -15,6 +15,7 @@ local resources = import '../specResources.libsonnet';
 local azureAdApplication = import './azureAdApplication.libsonnet';
 local externalSecrets = import './externalSecrets.libsonnet';
 local mounts = import './mounts.libsonnet';
+local destinationRule = import './destinationRule.libsonnet';
 {
   application: {
     new(name, image, port):
@@ -46,6 +47,7 @@ local mounts = import './mounts.libsonnet';
   + configMap
   + externalSecrets
   + mounts
+  + destinationRule
   + utils
   + resources,
 }

--- a/v2/lib/appAndObjects/destinationRule.libsonnet
+++ b/v2/lib/appAndObjects/destinationRule.libsonnet
@@ -7,13 +7,13 @@ local v = import '../../internal/validation.libsonnet';
    * 
    * Parameters:
    *  - cookieName: string (optional, default='ISTIO-STICKY') - The name of the cookie to use for sticky sessions
-   *  - cookiePath: string (optional, default='/') - The path for the cookie
+   *  - cookiePath: string (optional, default=null) - The path for the cookie. If not set, path is omitted from the cookie config
    *  - cookieTtl: string (optional, default='0') - The TTL for the cookie (0 means session cookie)
    */
-  withStickySession(cookieName='ISTIO-STICKY', cookiePath='/', cookieTtl='0')::
+  withStickySession(cookieName='ISTIO-STICKY', cookiePath=null, cookieTtl='0')::
     v.string(cookieName, 'cookieName') +
-    v.string(cookiePath, 'cookiePath') +
     v.string(cookieTtl, 'cookieTtl') +
+    (if cookiePath != null then v.string(cookiePath, 'cookiePath') else {}) +
     {
       local name = self.application.metadata.name,
       objects+: [
@@ -28,11 +28,11 @@ local v = import '../../internal/validation.libsonnet';
             trafficPolicy: {
               loadBalancer: {
                 consistentHash: {
-                  httpCookie: {
+                  httpCookie: std.prune({
                     name: cookieName,
-                    path: cookiePath,
+                    [if cookiePath != null then 'path']: cookiePath,
                     ttl: cookieTtl,
-                  },
+                  }),
                 },
               },
             },

--- a/v2/lib/appAndObjects/destinationRule.libsonnet
+++ b/v2/lib/appAndObjects/destinationRule.libsonnet
@@ -1,0 +1,43 @@
+local v = import '../../internal/validation.libsonnet';
+
+{
+  /**
+   * Creates an Istio DestinationRule for sticky sessions using consistent hash load balancing.
+   * This enables session affinity by routing requests from the same client to the same pod.
+   * 
+   * Parameters:
+   *  - cookieName: string (optional, default='ISTIO-STICKY') - The name of the cookie to use for sticky sessions
+   *  - cookiePath: string (optional, default='/') - The path for the cookie
+   *  - cookieTtl: string (optional, default='0') - The TTL for the cookie (0 means session cookie)
+   */
+  withStickySession(cookieName='ISTIO-STICKY', cookiePath='/', cookieTtl='0')::
+    v.string(cookieName, 'cookieName') +
+    v.string(cookiePath, 'cookiePath') +
+    v.string(cookieTtl, 'cookieTtl') +
+    {
+      local name = self.application.metadata.name,
+      objects+: [
+        {
+          apiVersion: 'networking.istio.io/v1',
+          kind: 'DestinationRule',
+          metadata: {
+            name: 'istio-sticky-' + name,
+          },
+          spec: {
+            host: name,
+            trafficPolicy: {
+              loadBalancer: {
+                consistentHash: {
+                  httpCookie: {
+                    name: cookieName,
+                    path: cookiePath,
+                    ttl: cookieTtl,
+                  },
+                },
+              },
+            },
+          },
+        },
+      ],
+    },
+}

--- a/v2/lib/appAndObjects/destinationRule.libsonnet
+++ b/v2/lib/appAndObjects/destinationRule.libsonnet
@@ -18,7 +18,7 @@ local v = import '../../internal/validation.libsonnet';
       local name = self.application.metadata.name,
       objects+: [
         {
-          apiVersion: 'networking.istio.io/v1',
+          apiVersion: 'networking.istio.io/v1alpha3',
           kind: 'DestinationRule',
           metadata: {
             name: 'istio-sticky-' + name,
@@ -35,6 +35,85 @@ local v = import '../../internal/validation.libsonnet';
                   }),
                 },
               },
+            },
+          },
+        },
+      ],
+    },
+
+  /**
+   * Creates an Istio DestinationRule for port-level TLS configuration.
+   * This enables TLS for specific ports on a service.
+   * 
+   * Parameters:
+   *  - host: string (required) - The target host (can be simple hostname or formatted like 'pod.service')
+   *  - port: number (optional, default=443) - The port number for TLS configuration
+   *  - tlsMode: string (optional, default='SIMPLE') - The TLS mode (ISTIO_MUTUAL, SIMPLE, MUTUAL, DISABLE)
+   *  - name: string (optional, default=null) - Custom name for the DestinationRule (defaults to application name)
+   */
+  withPortLevelTls(host, port=443, tlsMode='SIMPLE', name=null)::
+    v.string(host, 'host') +
+    v.number(port, 'port') +
+    v.string(tlsMode, 'tlsMode') +
+    (if name != null then v.string(name, 'name') else {}) +
+    {
+      local appName = self.application.metadata.name,
+      objects+: [
+        {
+          apiVersion: 'networking.istio.io/v1',
+          kind: 'DestinationRule',
+          metadata: {
+            name: if name != null then name else appName,
+          },
+          spec: {
+            host: host,
+            trafficPolicy: {
+              portLevelSettings: [
+                {
+                  port: {
+                    number: port,
+                  },
+                  tls: {
+                    mode: tlsMode,
+                  },
+                },
+              ],
+            },
+          },
+        },
+      ],
+    },
+
+  /**
+   * Creates an Istio DestinationRule with traffic policy TLS configuration.
+   * This configures TLS settings for outbound traffic to external services with SNI support.
+   * 
+   * Parameters:
+   *  - name: string (required) - The name for the DestinationRule
+   *  - host: string (required) - The external host
+   *  - tlsMode: string (optional, default='SIMPLE') - The TLS mode (SIMPLE, MUTUAL, ISTIO_MUTUAL, DISABLE)
+   *  - sni: string (optional, default=null) - The SNI string to present to the server during TLS handshake
+   */
+  withTrafficPolicyTls(name, host, tlsMode='SIMPLE', sni=null)::
+    v.string(name, 'name') +
+    v.string(host, 'host') +
+    v.string(tlsMode, 'tlsMode') +
+    (if sni != null then v.string(sni, 'sni') else {}) +
+    {
+      objects+: [
+        {
+          apiVersion: 'networking.istio.io/v1',
+          kind: 'DestinationRule',
+          metadata: {
+            name: name,
+          },
+          spec: {
+            host: host,
+            trafficPolicy: {
+              tls: std.prune({
+                mode: tlsMode,
+                [if sni != null then 'sni']: sni,
+              }),
             },
           },
         },

--- a/v2/tests/destinationRule_test.jsonnet
+++ b/v2/tests/destinationRule_test.jsonnet
@@ -35,8 +35,8 @@ test.new(std.thisFile)
           name: 'test-app',
           labels: {
             'skip.kartverket.no/argokit-flavor': 'v2',
-            'skip.kartverket.no/argokit-git-ref': 'edbabd565a7515ba8cd3909631396344c5a3a2ee',
-            'skip.kartverket.no/argokit-tag': 'dev-dirty',
+            'skip.kartverket.no/argokit-git-ref': '3c61c1df6be098f3e805ad93efd8cfa2e0ffa366',
+            'skip.kartverket.no/argokit-tag': 'dev-332',
           },
         },
         spec: {
@@ -80,8 +80,8 @@ test.new(std.thisFile)
           name: 'test-app',
           labels: {
             'skip.kartverket.no/argokit-flavor': 'v2',
-            'skip.kartverket.no/argokit-git-ref': 'edbabd565a7515ba8cd3909631396344c5a3a2ee',
-            'skip.kartverket.no/argokit-tag': 'dev-dirty',
+            'skip.kartverket.no/argokit-git-ref': '3c61c1df6be098f3e805ad93efd8cfa2e0ffa366',
+            'skip.kartverket.no/argokit-tag': 'dev-332',
           },
         },
         spec: {
@@ -104,8 +104,8 @@ test.new(std.thisFile)
           name: 'aal-register',
           labels: {
             'skip.kartverket.no/argokit-flavor': 'v2',
-            'skip.kartverket.no/argokit-git-ref': 'edbabd565a7515ba8cd3909631396344c5a3a2ee',
-            'skip.kartverket.no/argokit-tag': 'dev-dirty',
+            'skip.kartverket.no/argokit-git-ref': '3c61c1df6be098f3e805ad93efd8cfa2e0ffa366',
+            'skip.kartverket.no/argokit-tag': 'dev-332',
           },
         },
         spec: {
@@ -148,8 +148,8 @@ test.new(std.thisFile)
           name: 'my-service',
           labels: {
             'skip.kartverket.no/argokit-flavor': 'v2',
-            'skip.kartverket.no/argokit-git-ref': 'edbabd565a7515ba8cd3909631396344c5a3a2ee',
-            'skip.kartverket.no/argokit-tag': 'dev-dirty',
+            'skip.kartverket.no/argokit-git-ref': '3c61c1df6be098f3e805ad93efd8cfa2e0ffa366',
+            'skip.kartverket.no/argokit-tag': 'dev-332',
           },
         },
         spec: {
@@ -216,8 +216,8 @@ test.new(std.thisFile)
           name: 'secure-app',
           labels: {
             'skip.kartverket.no/argokit-flavor': 'v2',
-            'skip.kartverket.no/argokit-git-ref': 'edbabd565a7515ba8cd3909631396344c5a3a2ee',
-            'skip.kartverket.no/argokit-tag': 'dev-dirty',
+            'skip.kartverket.no/argokit-git-ref': '3c61c1df6be098f3e805ad93efd8cfa2e0ffa366',
+            'skip.kartverket.no/argokit-tag': 'dev-332',
           },
         },
         spec: {
@@ -256,8 +256,8 @@ test.new(std.thisFile)
           name: 'my-app',
           labels: {
             'skip.kartverket.no/argokit-flavor': 'v2',
-            'skip.kartverket.no/argokit-git-ref': 'edbabd565a7515ba8cd3909631396344c5a3a2ee',
-            'skip.kartverket.no/argokit-tag': 'dev-dirty',
+            'skip.kartverket.no/argokit-git-ref': '3c61c1df6be098f3e805ad93efd8cfa2e0ffa366',
+            'skip.kartverket.no/argokit-tag': 'dev-332',
           },
         },
         spec: {
@@ -295,8 +295,8 @@ test.new(std.thisFile)
           name: 'my-app',
           labels: {
             'skip.kartverket.no/argokit-flavor': 'v2',
-            'skip.kartverket.no/argokit-git-ref': 'edbabd565a7515ba8cd3909631396344c5a3a2ee',
-            'skip.kartverket.no/argokit-tag': 'dev-dirty',
+            'skip.kartverket.no/argokit-git-ref': '3c61c1df6be098f3e805ad93efd8cfa2e0ffa366',
+            'skip.kartverket.no/argokit-tag': 'dev-332',
           },
         },
         spec: {

--- a/v2/tests/destinationRule_test.jsonnet
+++ b/v2/tests/destinationRule_test.jsonnet
@@ -1,0 +1,95 @@
+local argokit = import '../jsonnet/argokit.libsonnet';
+local test = import 'github.com/jsonnet-libs/testonnet/main.libsonnet';
+local application = argokit.appAndObjects.application;
+
+test.new(std.thisFile)
++ test.case.new(
+  name='application with sticky session using defaults',
+  test=test.expect.eqDiff(
+    actual=(application.new('test-app', 'test:1.0', 8080) + application.withStickySession()).items,
+    expected=[
+      {
+        apiVersion: 'networking.istio.io/v1',
+        kind: 'DestinationRule',
+        metadata: {
+          name: 'istio-sticky-test-app',
+        },
+        spec: {
+          host: 'test-app',
+          trafficPolicy: {
+            loadBalancer: {
+              consistentHash: {
+                httpCookie: {
+                  name: 'ISTIO-STICKY',
+                  path: '/',
+                  ttl: '0',
+                },
+              },
+            },
+          },
+        },
+      },
+      {
+        apiVersion: 'skiperator.kartverket.no/v1alpha1',
+        kind: 'Application',
+        metadata: {
+          name: 'test-app',
+          labels: {
+            'skip.kartverket.no/argokit-flavor': 'v2',
+            'skip.kartverket.no/argokit-git-ref': '7dc5c1e46a97fe6e0cb11555d435d9c1f75ecc96',
+            'skip.kartverket.no/argokit-tag': 'dev-315',
+          },
+        },
+        spec: {
+          image: 'test:1.0',
+          port: 8080,
+        },
+      },
+    ],
+  ),
+)
++ test.case.new(
+  name='application with custom sticky session parameters',
+  test=test.expect.eqDiff(
+    actual=(application.new('test-app', 'test:1.0', 8080) + application.withStickySession(cookieName='MY-SESSION', cookiePath='/api', cookieTtl='3600s')).items,
+    expected=[
+      {
+        apiVersion: 'networking.istio.io/v1',
+        kind: 'DestinationRule',
+        metadata: {
+          name: 'istio-sticky-test-app',
+        },
+        spec: {
+          host: 'test-app',
+          trafficPolicy: {
+            loadBalancer: {
+              consistentHash: {
+                httpCookie: {
+                  name: 'MY-SESSION',
+                  path: '/api',
+                  ttl: '3600s',
+                },
+              },
+            },
+          },
+        },
+      },
+      {
+        apiVersion: 'skiperator.kartverket.no/v1alpha1',
+        kind: 'Application',
+        metadata: {
+          name: 'test-app',
+          labels: {
+            'skip.kartverket.no/argokit-flavor': 'v2',
+            'skip.kartverket.no/argokit-git-ref': '7dc5c1e46a97fe6e0cb11555d435d9c1f75ecc96',
+            'skip.kartverket.no/argokit-tag': 'dev-315',
+          },
+        },
+        spec: {
+          image: 'test:1.0',
+          port: 8080,
+        },
+      },
+    ],
+  ),
+)

--- a/v2/tests/destinationRule_test.jsonnet
+++ b/v2/tests/destinationRule_test.jsonnet
@@ -4,7 +4,7 @@ local application = argokit.appAndObjects.application;
 
 test.new(std.thisFile)
 + test.case.new(
-  name='application with sticky session using defaults',
+  name='application with sticky session using defaults (no path)',
   test=test.expect.eqDiff(
     actual=(application.new('test-app', 'test:1.0', 8080) + application.withStickySession()).items,
     expected=[
@@ -21,7 +21,6 @@ test.new(std.thisFile)
               consistentHash: {
                 httpCookie: {
                   name: 'ISTIO-STICKY',
-                  path: '/',
                   ttl: '0',
                 },
               },
@@ -49,7 +48,7 @@ test.new(std.thisFile)
   ),
 )
 + test.case.new(
-  name='application with custom sticky session parameters',
+  name='application with custom sticky session parameters including path',
   test=test.expect.eqDiff(
     actual=(application.new('test-app', 'test:1.0', 8080) + application.withStickySession(cookieName='MY-SESSION', cookiePath='/api', cookieTtl='3600s')).items,
     expected=[
@@ -87,6 +86,50 @@ test.new(std.thisFile)
         },
         spec: {
           image: 'test:1.0',
+          port: 8080,
+        },
+      },
+    ],
+  ),
+)
++ test.case.new(
+  name='application with custom cookie name and ttl without path',
+  test=test.expect.eqDiff(
+    actual=(application.new('aal-register', 'aal:1.0', 8080) + application.withStickySession(cookieName='AAL-SESSION', cookieTtl='1800s')).items,
+    expected=[
+      {
+        apiVersion: 'networking.istio.io/v1',
+        kind: 'DestinationRule',
+        metadata: {
+          name: 'istio-sticky-aal-register',
+        },
+        spec: {
+          host: 'aal-register',
+          trafficPolicy: {
+            loadBalancer: {
+              consistentHash: {
+                httpCookie: {
+                  name: 'AAL-SESSION',
+                  ttl: '1800s',
+                },
+              },
+            },
+          },
+        },
+      },
+      {
+        apiVersion: 'skiperator.kartverket.no/v1alpha1',
+        kind: 'Application',
+        metadata: {
+          name: 'aal-register',
+          labels: {
+            'skip.kartverket.no/argokit-flavor': 'v2',
+            'skip.kartverket.no/argokit-git-ref': '7dc5c1e46a97fe6e0cb11555d435d9c1f75ecc96',
+            'skip.kartverket.no/argokit-tag': 'dev-315',
+          },
+        },
+        spec: {
+          image: 'aal:1.0',
           port: 8080,
         },
       },

--- a/v2/tests/destinationRule_test.jsonnet
+++ b/v2/tests/destinationRule_test.jsonnet
@@ -2,308 +2,183 @@ local argokit = import '../jsonnet/argokit.libsonnet';
 local test = import 'github.com/jsonnet-libs/testonnet/main.libsonnet';
 local application = argokit.appAndObjects.application;
 
+local stripLabels(o) = std.prune(o { metadata+: { labels: null } });
+
+local stickySessionApp =
+  application.new('aal-register', 'aal:1.0', 8080)
+  + application.withStickySession('AAL-SESSION', null, '1800s');
+
+local portLevelTlsApp =
+  application.new('secure-app', 'secure:2.0', 9000)
+  + application.withPortLevelTls('secure-pod.secure-svc', 80, 'ISTIO_MUTUAL', 'custom-dr-name');
+
+local trafficTlsSniApp =
+  application.new('my-app', 'app:1.0', 8080)
+  + application.withTrafficPolicyTls('jenkins-matrikkel-no', 'jenkins.matrikkel.no', 'SIMPLE', 'jenkins.matrikkel.no');
+
+local trafficTlsApp =
+  application.new('my-app', 'app:1.0', 8080)
+  + application.withTrafficPolicyTls('external-service', 'external.example.com');
+
 test.new(std.thisFile)
 + test.case.new(
-  name='application with sticky session using defaults (no path)',
+  name='application with sticky session',
   test=test.expect.eqDiff(
-    actual=(application.new('test-app', 'test:1.0', 8080) + application.withStickySession()).items,
-    expected=[
-      {
-        apiVersion: 'networking.istio.io/v1alpha3',
-        kind: 'DestinationRule',
-        metadata: {
-          name: 'istio-sticky-test-app',
+    actual=std.map(stripLabels, stickySessionApp.items),
+    expected=std.map(
+      stripLabels,
+      [
+        {
+          apiVersion: 'skiperator.kartverket.no/v1alpha1',
+          kind: 'Application',
+          metadata: {
+            name: 'aal-register',
+          },
+          spec: {
+            image: 'aal:1.0',
+            port: 8080,
+          },
         },
-        spec: {
-          host: 'test-app',
-          trafficPolicy: {
-            loadBalancer: {
-              consistentHash: {
-                httpCookie: {
-                  name: 'ISTIO-STICKY',
-                  ttl: '0',
+        {
+          apiVersion: 'networking.istio.io/v1alpha3',
+          kind: 'DestinationRule',
+          metadata: {
+            name: 'istio-sticky-aal-register',
+          },
+          spec: {
+            host: 'aal-register',
+            trafficPolicy: {
+              loadBalancer: {
+                consistentHash: {
+                  httpCookie: {
+                    name: 'AAL-SESSION',
+                    ttl: '1800s',
+                  },
                 },
               },
             },
           },
         },
-      },
-      {
-        apiVersion: 'skiperator.kartverket.no/v1alpha1',
-        kind: 'Application',
-        metadata: {
-          name: 'test-app',
-          labels: {
-            'skip.kartverket.no/argokit-flavor': 'v2',
-            'skip.kartverket.no/argokit-git-ref': '3c61c1df6be098f3e805ad93efd8cfa2e0ffa366',
-            'skip.kartverket.no/argokit-tag': 'dev-332',
-          },
-        },
-        spec: {
-          image: 'test:1.0',
-          port: 8080,
-        },
-      },
-    ],
-  ),
-)
-+ test.case.new(
-  name='application with custom sticky session parameters including path',
-  test=test.expect.eqDiff(
-    actual=(application.new('test-app', 'test:1.0', 8080) + application.withStickySession(cookieName='MY-SESSION', cookiePath='/api', cookieTtl='3600s')).items,
-    expected=[
-      {
-        apiVersion: 'networking.istio.io/v1alpha3',
-        kind: 'DestinationRule',
-        metadata: {
-          name: 'istio-sticky-test-app',
-        },
-        spec: {
-          host: 'test-app',
-          trafficPolicy: {
-            loadBalancer: {
-              consistentHash: {
-                httpCookie: {
-                  name: 'MY-SESSION',
-                  path: '/api',
-                  ttl: '3600s',
-                },
-              },
-            },
-          },
-        },
-      },
-      {
-        apiVersion: 'skiperator.kartverket.no/v1alpha1',
-        kind: 'Application',
-        metadata: {
-          name: 'test-app',
-          labels: {
-            'skip.kartverket.no/argokit-flavor': 'v2',
-            'skip.kartverket.no/argokit-git-ref': '3c61c1df6be098f3e805ad93efd8cfa2e0ffa366',
-            'skip.kartverket.no/argokit-tag': 'dev-332',
-          },
-        },
-        spec: {
-          image: 'test:1.0',
-          port: 8080,
-        },
-      },
-    ],
-  ),
-)
-+ test.case.new(
-  name='application with custom cookie name and ttl without path',
-  test=test.expect.eqDiff(
-    actual=(application.new('aal-register', 'aal:1.0', 8080) + application.withStickySession(cookieName='AAL-SESSION', cookieTtl='1800s')).items,
-    expected=[
-      {
-        apiVersion: 'skiperator.kartverket.no/v1alpha1',
-        kind: 'Application',
-        metadata: {
-          name: 'aal-register',
-          labels: {
-            'skip.kartverket.no/argokit-flavor': 'v2',
-            'skip.kartverket.no/argokit-git-ref': '3c61c1df6be098f3e805ad93efd8cfa2e0ffa366',
-            'skip.kartverket.no/argokit-tag': 'dev-332',
-          },
-        },
-        spec: {
-          image: 'aal:1.0',
-          port: 8080,
-        },
-      },
-      {
-        apiVersion: 'networking.istio.io/v1alpha3',
-        kind: 'DestinationRule',
-        metadata: {
-          name: 'istio-sticky-aal-register',
-        },
-        spec: {
-          host: 'aal-register',
-          trafficPolicy: {
-            loadBalancer: {
-              consistentHash: {
-                httpCookie: {
-                  name: 'AAL-SESSION',
-                  ttl: '1800s',
-                },
-              },
-            },
-          },
-        },
-      },
-    ],
-  ),
-)
-+ test.case.new(
-  name='application with port-level TLS using defaults',
-  test=test.expect.eqDiff(
-    actual=(application.new('my-service', 'myapp:1.0', 8080) + application.withPortLevelTls('external.example.com')).items,
-    expected=[
-      {
-        apiVersion: 'skiperator.kartverket.no/v1alpha1',
-        kind: 'Application',
-        metadata: {
-          name: 'my-service',
-          labels: {
-            'skip.kartverket.no/argokit-flavor': 'v2',
-            'skip.kartverket.no/argokit-git-ref': '3c61c1df6be098f3e805ad93efd8cfa2e0ffa366',
-            'skip.kartverket.no/argokit-tag': 'dev-332',
-          },
-        },
-        spec: {
-          image: 'myapp:1.0',
-          port: 8080,
-        },
-      },
-      {
-        apiVersion: 'networking.istio.io/v1',
-        kind: 'DestinationRule',
-        metadata: {
-          name: 'my-service',
-        },
-        spec: {
-          host: 'external.example.com',
-          trafficPolicy: {
-            portLevelSettings: [
-              {
-                port: {
-                  number: 443,
-                },
-                tls: {
-                  mode: 'SIMPLE',
-                },
-              },
-            ],
-          },
-        },
-      },
-    ],
+      ],
+    ),
   ),
 )
 + test.case.new(
   name='application with custom port-level TLS configuration',
   test=test.expect.eqDiff(
-    actual=(application.new('secure-app', 'secure:2.0', 9000) + application.withPortLevelTls('secure-pod.secure-svc', 80, 'ISTIO_MUTUAL', 'custom-dr-name')).items,
-    expected=[
-      {
-        apiVersion: 'networking.istio.io/v1',
-        kind: 'DestinationRule',
-        metadata: {
-          name: 'custom-dr-name',
-        },
-        spec: {
-          host: 'secure-pod.secure-svc',
-          trafficPolicy: {
-            portLevelSettings: [
-              {
-                port: {
-                  number: 80,
+    actual=std.map(stripLabels, portLevelTlsApp.items),
+    expected=std.map(
+      stripLabels,
+      [
+        {
+          apiVersion: 'networking.istio.io/v1',
+          kind: 'DestinationRule',
+          metadata: {
+            name: 'custom-dr-name',
+          },
+          spec: {
+            host: 'secure-pod.secure-svc',
+            trafficPolicy: {
+              portLevelSettings: [
+                {
+                  port: {
+                    number: 80,
+                  },
+                  tls: {
+                    mode: 'ISTIO_MUTUAL',
+                  },
                 },
-                tls: {
-                  mode: 'ISTIO_MUTUAL',
-                },
-              },
-            ],
+              ],
+            },
           },
         },
-      },
-      {
-        apiVersion: 'skiperator.kartverket.no/v1alpha1',
-        kind: 'Application',
-        metadata: {
-          name: 'secure-app',
-          labels: {
-            'skip.kartverket.no/argokit-flavor': 'v2',
-            'skip.kartverket.no/argokit-git-ref': '3c61c1df6be098f3e805ad93efd8cfa2e0ffa366',
-            'skip.kartverket.no/argokit-tag': 'dev-332',
+        {
+          apiVersion: 'skiperator.kartverket.no/v1alpha1',
+          kind: 'Application',
+          metadata: {
+            name: 'secure-app',
+          },
+          spec: {
+            image: 'secure:2.0',
+            port: 9000,
           },
         },
-        spec: {
-          image: 'secure:2.0',
-          port: 9000,
-        },
-      },
-    ],
+      ],
+    ),
   ),
 )
 + test.case.new(
   name='application with traffic policy TLS and SNI',
   test=test.expect.eqDiff(
-    actual=(application.new('my-app', 'app:1.0', 8080) + application.withTrafficPolicyTls('jenkins-matrikkel-no', 'jenkins.matrikkel.no', 'SIMPLE', 'jenkins.matrikkel.no')).items,
-    expected=[
-      {
-        apiVersion: 'networking.istio.io/v1',
-        kind: 'DestinationRule',
-        metadata: {
-          name: 'jenkins-matrikkel-no',
-        },
-        spec: {
-          host: 'jenkins.matrikkel.no',
-          trafficPolicy: {
-            tls: {
-              mode: 'SIMPLE',
-              sni: 'jenkins.matrikkel.no',
+    actual=std.map(stripLabels, trafficTlsSniApp.items),
+    expected=std.map(
+      stripLabels,
+      [
+        {
+          apiVersion: 'networking.istio.io/v1',
+          kind: 'DestinationRule',
+          metadata: {
+            name: 'jenkins-matrikkel-no',
+          },
+          spec: {
+            host: 'jenkins.matrikkel.no',
+            trafficPolicy: {
+              tls: {
+                mode: 'SIMPLE',
+                sni: 'jenkins.matrikkel.no',
+              },
             },
           },
         },
-      },
-      {
-        apiVersion: 'skiperator.kartverket.no/v1alpha1',
-        kind: 'Application',
-        metadata: {
-          name: 'my-app',
-          labels: {
-            'skip.kartverket.no/argokit-flavor': 'v2',
-            'skip.kartverket.no/argokit-git-ref': '3c61c1df6be098f3e805ad93efd8cfa2e0ffa366',
-            'skip.kartverket.no/argokit-tag': 'dev-332',
+        {
+          apiVersion: 'skiperator.kartverket.no/v1alpha1',
+          kind: 'Application',
+          metadata: {
+            name: 'my-app',
+          },
+          spec: {
+            image: 'app:1.0',
+            port: 8080,
           },
         },
-        spec: {
-          image: 'app:1.0',
-          port: 8080,
-        },
-      },
-    ],
+      ],
+    ),
   ),
 )
 + test.case.new(
   name='application with traffic policy TLS without SNI',
   test=test.expect.eqDiff(
-    actual=(application.new('my-app', 'app:1.0', 8080) + application.withTrafficPolicyTls('external-service', 'external.example.com')).items,
-    expected=[
-      {
-        apiVersion: 'networking.istio.io/v1',
-        kind: 'DestinationRule',
-        metadata: {
-          name: 'external-service',
-        },
-        spec: {
-          host: 'external.example.com',
-          trafficPolicy: {
-            tls: {
-              mode: 'SIMPLE',
+    actual=std.map(stripLabels, trafficTlsApp.items),
+    expected=std.map(
+      stripLabels,
+      [
+        {
+          apiVersion: 'networking.istio.io/v1',
+          kind: 'DestinationRule',
+          metadata: {
+            name: 'external-service',
+          },
+          spec: {
+            host: 'external.example.com',
+            trafficPolicy: {
+              tls: {
+                mode: 'SIMPLE',
+              },
             },
           },
         },
-      },
-      {
-        apiVersion: 'skiperator.kartverket.no/v1alpha1',
-        kind: 'Application',
-        metadata: {
-          name: 'my-app',
-          labels: {
-            'skip.kartverket.no/argokit-flavor': 'v2',
-            'skip.kartverket.no/argokit-git-ref': '3c61c1df6be098f3e805ad93efd8cfa2e0ffa366',
-            'skip.kartverket.no/argokit-tag': 'dev-332',
+        {
+          apiVersion: 'skiperator.kartverket.no/v1alpha1',
+          kind: 'Application',
+          metadata: {
+            name: 'my-app',
+          },
+          spec: {
+            image: 'app:1.0',
+            port: 8080,
           },
         },
-        spec: {
-          image: 'app:1.0',
-          port: 8080,
-        },
-      },
-    ],
+      ],
+    ),
   ),
 )

--- a/v2/tests/destinationRule_test.jsonnet
+++ b/v2/tests/destinationRule_test.jsonnet
@@ -35,8 +35,8 @@ test.new(std.thisFile)
           name: 'test-app',
           labels: {
             'skip.kartverket.no/argokit-flavor': 'v2',
-            'skip.kartverket.no/argokit-git-ref': '7dc5c1e46a97fe6e0cb11555d435d9c1f75ecc96',
-            'skip.kartverket.no/argokit-tag': 'dev-315',
+            'skip.kartverket.no/argokit-git-ref': 'a838ee16fbc34ba7efba0be7c0d5a16fe7e7945c',
+            'skip.kartverket.no/argokit-tag': 'dev-327',
           },
         },
         spec: {
@@ -80,8 +80,8 @@ test.new(std.thisFile)
           name: 'test-app',
           labels: {
             'skip.kartverket.no/argokit-flavor': 'v2',
-            'skip.kartverket.no/argokit-git-ref': '7dc5c1e46a97fe6e0cb11555d435d9c1f75ecc96',
-            'skip.kartverket.no/argokit-tag': 'dev-315',
+            'skip.kartverket.no/argokit-git-ref': 'a838ee16fbc34ba7efba0be7c0d5a16fe7e7945c',
+            'skip.kartverket.no/argokit-tag': 'dev-327',
           },
         },
         spec: {
@@ -97,6 +97,22 @@ test.new(std.thisFile)
   test=test.expect.eqDiff(
     actual=(application.new('aal-register', 'aal:1.0', 8080) + application.withStickySession(cookieName='AAL-SESSION', cookieTtl='1800s')).items,
     expected=[
+      {
+        apiVersion: 'skiperator.kartverket.no/v1alpha1',
+        kind: 'Application',
+        metadata: {
+          name: 'aal-register',
+          labels: {
+            'skip.kartverket.no/argokit-flavor': 'v2',
+            'skip.kartverket.no/argokit-git-ref': 'a838ee16fbc34ba7efba0be7c0d5a16fe7e7945c',
+            'skip.kartverket.no/argokit-tag': 'dev-327',
+          },
+        },
+        spec: {
+          image: 'aal:1.0',
+          port: 8080,
+        },
+      },
       {
         apiVersion: 'networking.istio.io/v1',
         kind: 'DestinationRule',
@@ -115,22 +131,6 @@ test.new(std.thisFile)
               },
             },
           },
-        },
-      },
-      {
-        apiVersion: 'skiperator.kartverket.no/v1alpha1',
-        kind: 'Application',
-        metadata: {
-          name: 'aal-register',
-          labels: {
-            'skip.kartverket.no/argokit-flavor': 'v2',
-            'skip.kartverket.no/argokit-git-ref': '7dc5c1e46a97fe6e0cb11555d435d9c1f75ecc96',
-            'skip.kartverket.no/argokit-tag': 'dev-315',
-          },
-        },
-        spec: {
-          image: 'aal:1.0',
-          port: 8080,
         },
       },
     ],

--- a/v2/tests/destinationRule_test.jsonnet
+++ b/v2/tests/destinationRule_test.jsonnet
@@ -9,7 +9,7 @@ test.new(std.thisFile)
     actual=(application.new('test-app', 'test:1.0', 8080) + application.withStickySession()).items,
     expected=[
       {
-        apiVersion: 'networking.istio.io/v1',
+        apiVersion: 'networking.istio.io/v1alpha3',
         kind: 'DestinationRule',
         metadata: {
           name: 'istio-sticky-test-app',
@@ -35,8 +35,8 @@ test.new(std.thisFile)
           name: 'test-app',
           labels: {
             'skip.kartverket.no/argokit-flavor': 'v2',
-            'skip.kartverket.no/argokit-git-ref': 'a838ee16fbc34ba7efba0be7c0d5a16fe7e7945c',
-            'skip.kartverket.no/argokit-tag': 'dev-327',
+            'skip.kartverket.no/argokit-git-ref': 'edbabd565a7515ba8cd3909631396344c5a3a2ee',
+            'skip.kartverket.no/argokit-tag': 'dev-dirty',
           },
         },
         spec: {
@@ -53,7 +53,7 @@ test.new(std.thisFile)
     actual=(application.new('test-app', 'test:1.0', 8080) + application.withStickySession(cookieName='MY-SESSION', cookiePath='/api', cookieTtl='3600s')).items,
     expected=[
       {
-        apiVersion: 'networking.istio.io/v1',
+        apiVersion: 'networking.istio.io/v1alpha3',
         kind: 'DestinationRule',
         metadata: {
           name: 'istio-sticky-test-app',
@@ -80,8 +80,8 @@ test.new(std.thisFile)
           name: 'test-app',
           labels: {
             'skip.kartverket.no/argokit-flavor': 'v2',
-            'skip.kartverket.no/argokit-git-ref': 'a838ee16fbc34ba7efba0be7c0d5a16fe7e7945c',
-            'skip.kartverket.no/argokit-tag': 'dev-327',
+            'skip.kartverket.no/argokit-git-ref': 'edbabd565a7515ba8cd3909631396344c5a3a2ee',
+            'skip.kartverket.no/argokit-tag': 'dev-dirty',
           },
         },
         spec: {
@@ -104,8 +104,8 @@ test.new(std.thisFile)
           name: 'aal-register',
           labels: {
             'skip.kartverket.no/argokit-flavor': 'v2',
-            'skip.kartverket.no/argokit-git-ref': 'a838ee16fbc34ba7efba0be7c0d5a16fe7e7945c',
-            'skip.kartverket.no/argokit-tag': 'dev-327',
+            'skip.kartverket.no/argokit-git-ref': 'edbabd565a7515ba8cd3909631396344c5a3a2ee',
+            'skip.kartverket.no/argokit-tag': 'dev-dirty',
           },
         },
         spec: {
@@ -114,7 +114,7 @@ test.new(std.thisFile)
         },
       },
       {
-        apiVersion: 'networking.istio.io/v1',
+        apiVersion: 'networking.istio.io/v1alpha3',
         kind: 'DestinationRule',
         metadata: {
           name: 'istio-sticky-aal-register',
@@ -131,6 +131,177 @@ test.new(std.thisFile)
               },
             },
           },
+        },
+      },
+    ],
+  ),
+)
++ test.case.new(
+  name='application with port-level TLS using defaults',
+  test=test.expect.eqDiff(
+    actual=(application.new('my-service', 'myapp:1.0', 8080) + application.withPortLevelTls('external.example.com')).items,
+    expected=[
+      {
+        apiVersion: 'skiperator.kartverket.no/v1alpha1',
+        kind: 'Application',
+        metadata: {
+          name: 'my-service',
+          labels: {
+            'skip.kartverket.no/argokit-flavor': 'v2',
+            'skip.kartverket.no/argokit-git-ref': 'edbabd565a7515ba8cd3909631396344c5a3a2ee',
+            'skip.kartverket.no/argokit-tag': 'dev-dirty',
+          },
+        },
+        spec: {
+          image: 'myapp:1.0',
+          port: 8080,
+        },
+      },
+      {
+        apiVersion: 'networking.istio.io/v1',
+        kind: 'DestinationRule',
+        metadata: {
+          name: 'my-service',
+        },
+        spec: {
+          host: 'external.example.com',
+          trafficPolicy: {
+            portLevelSettings: [
+              {
+                port: {
+                  number: 443,
+                },
+                tls: {
+                  mode: 'SIMPLE',
+                },
+              },
+            ],
+          },
+        },
+      },
+    ],
+  ),
+)
++ test.case.new(
+  name='application with custom port-level TLS configuration',
+  test=test.expect.eqDiff(
+    actual=(application.new('secure-app', 'secure:2.0', 9000) + application.withPortLevelTls('secure-pod.secure-svc', 80, 'ISTIO_MUTUAL', 'custom-dr-name')).items,
+    expected=[
+      {
+        apiVersion: 'networking.istio.io/v1',
+        kind: 'DestinationRule',
+        metadata: {
+          name: 'custom-dr-name',
+        },
+        spec: {
+          host: 'secure-pod.secure-svc',
+          trafficPolicy: {
+            portLevelSettings: [
+              {
+                port: {
+                  number: 80,
+                },
+                tls: {
+                  mode: 'ISTIO_MUTUAL',
+                },
+              },
+            ],
+          },
+        },
+      },
+      {
+        apiVersion: 'skiperator.kartverket.no/v1alpha1',
+        kind: 'Application',
+        metadata: {
+          name: 'secure-app',
+          labels: {
+            'skip.kartverket.no/argokit-flavor': 'v2',
+            'skip.kartverket.no/argokit-git-ref': 'edbabd565a7515ba8cd3909631396344c5a3a2ee',
+            'skip.kartverket.no/argokit-tag': 'dev-dirty',
+          },
+        },
+        spec: {
+          image: 'secure:2.0',
+          port: 9000,
+        },
+      },
+    ],
+  ),
+)
++ test.case.new(
+  name='application with traffic policy TLS and SNI',
+  test=test.expect.eqDiff(
+    actual=(application.new('my-app', 'app:1.0', 8080) + application.withTrafficPolicyTls('jenkins-matrikkel-no', 'jenkins.matrikkel.no', 'SIMPLE', 'jenkins.matrikkel.no')).items,
+    expected=[
+      {
+        apiVersion: 'networking.istio.io/v1',
+        kind: 'DestinationRule',
+        metadata: {
+          name: 'jenkins-matrikkel-no',
+        },
+        spec: {
+          host: 'jenkins.matrikkel.no',
+          trafficPolicy: {
+            tls: {
+              mode: 'SIMPLE',
+              sni: 'jenkins.matrikkel.no',
+            },
+          },
+        },
+      },
+      {
+        apiVersion: 'skiperator.kartverket.no/v1alpha1',
+        kind: 'Application',
+        metadata: {
+          name: 'my-app',
+          labels: {
+            'skip.kartverket.no/argokit-flavor': 'v2',
+            'skip.kartverket.no/argokit-git-ref': 'edbabd565a7515ba8cd3909631396344c5a3a2ee',
+            'skip.kartverket.no/argokit-tag': 'dev-dirty',
+          },
+        },
+        spec: {
+          image: 'app:1.0',
+          port: 8080,
+        },
+      },
+    ],
+  ),
+)
++ test.case.new(
+  name='application with traffic policy TLS without SNI',
+  test=test.expect.eqDiff(
+    actual=(application.new('my-app', 'app:1.0', 8080) + application.withTrafficPolicyTls('external-service', 'external.example.com')).items,
+    expected=[
+      {
+        apiVersion: 'networking.istio.io/v1',
+        kind: 'DestinationRule',
+        metadata: {
+          name: 'external-service',
+        },
+        spec: {
+          host: 'external.example.com',
+          trafficPolicy: {
+            tls: {
+              mode: 'SIMPLE',
+            },
+          },
+        },
+      },
+      {
+        apiVersion: 'skiperator.kartverket.no/v1alpha1',
+        kind: 'Application',
+        metadata: {
+          name: 'my-app',
+          labels: {
+            'skip.kartverket.no/argokit-flavor': 'v2',
+            'skip.kartverket.no/argokit-git-ref': 'edbabd565a7515ba8cd3909631396344c5a3a2ee',
+            'skip.kartverket.no/argokit-tag': 'dev-dirty',
+          },
+        },
+        spec: {
+          image: 'app:1.0',
+          port: 8080,
         },
       },
     ],

--- a/version.libsonnet
+++ b/version.libsonnet
@@ -1,4 +1,4 @@
 {
-  sha: 'a838ee16fbc34ba7efba0be7c0d5a16fe7e7945c',
-  tag: 'dev-327',
+  sha: 'edbabd565a7515ba8cd3909631396344c5a3a2ee',
+  tag: 'dev-dirty',
 }

--- a/version.libsonnet
+++ b/version.libsonnet
@@ -1,4 +1,4 @@
 {
-  sha: 'edbabd565a7515ba8cd3909631396344c5a3a2ee',
-  tag: 'dev-dirty',
+  sha: '3c61c1df6be098f3e805ad93efd8cfa2e0ffa366',
+  tag: 'dev-332',
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description 📝
Added three new functions to support Istio DestinationRule configurations in ArgoKit v2:

withStickySession() - Cookie-based sticky sessions using consistent hash load balancing
withPortLevelTls() - Port-specific TLS configuration for services
withTrafficPolicyTls() - Traffic policy TLS with SNI support for external services

## Motivation and Context 💡
ultiple app repos at Kartverket use DestinationRules for sticky sessions and TLS configuration. This PR implements support for these patterns 

## How Has This Been Tested? 🧪
Tested on the skvis app repo and see that it renders correctly. for stickySession

## Types of changes 🔄
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue) 🐛
- [x] New feature (non-breaking change which adds functionality) ✨
- [ ] Breaking change (fix or feature that would cause existing functionality to change) 💥

## Checklist: ✅
- [ ] My code follows the code style of this project. 💅
- [x] My changes do not break the existing tests 🧪
- [x] I have updated the tests accordingly ➕ 
- [x] My change requires a change to the documentation. 📚
- [x] I have updated the documentation accordingly. 📝