### PR TITLE
Support fetching properties in GSM Secrets

### DIFF
--- a/examples/jsonnet/secretstore-gsm.jsonnet
+++ b/examples/jsonnet/secretstore-gsm.jsonnet
@@ -13,6 +13,16 @@ local argokit = import '../../jsonnet/argokit.libsonnet';
     }],
   },
 
+  // Fetch a JSON secret's content and write the password property to a kubernetes
+  // secret on the key "DB_PASSWORD"
+  argokit.GSMSecret('dbpass') {
+    secrets: [{
+      fromSecret: 'db-pass-json',
+      property: 'password',
+      toKey: 'DB_PASSWORD',
+    }],
+  },
+
   // Fetch a structured JSON object from a and map
   // keys and values to the kubernetes secret
   argokit.GSMSecret('allkeys') {

--- a/jsonnet/argokit.libsonnet
+++ b/jsonnet/argokit.libsonnet
@@ -82,6 +82,7 @@ local environment = import '../lib/environment.libsonnet';
         secretKey: secret.toKey,
         remoteRef: {
           key: secret.fromSecret,
+          [if std.objectHas(secret, 'property') then 'property']: secret.property,
           metadataPolicy: 'None',
         },
       } for secret in input.secrets],

--- a/v2/lib/resources/externalSecrets.libsonnet
+++ b/v2/lib/resources/externalSecrets.libsonnet
@@ -22,12 +22,13 @@ local v = import '../../internal/validation.libsonnet';
       }
   } + utils.withArgokitVersionLabel(flavor='v2'),
   secret: {
-    new(name, creationPolicy=null, secrets=[], allKeysFrom=[], secretStoreRef='gsm')::
+    new(name, creationPolicy=null, secrets=[], allKeysFrom=[], secretStoreRef='gsm', property=null)::
       v.string(name, 'name') +
       (if creationPolicy != null then v.string(creationPolicy, 'creationPolicy') else {}) +
       v.array(secrets, 'secrets', allowEmpty=true) +
       v.array(allKeysFrom, 'allKeysFrom', allowEmpty=true) +
       v.string(secretStoreRef, 'secretStoreRef', allowEmpty=true) +
+      (if property != null then v.string(property, 'property') else {}) +
       (if std.length(secrets) > 0 || std.length(allKeysFrom) > 0 then {}
        else error 'invalid secret: either secrets or allKeysFrom must contain at least one item') +
 
@@ -43,18 +44,20 @@ local v = import '../../internal/validation.libsonnet';
             remoteRef: std.prune({
               conversionStrategy: std.get(secret, 'conversionStrategy', 'Default'),
               decodingStrategy: std.get(secret, 'decodingStrategy', 'None'),
+              nullBytePolicy: std.get(secret, 'nullBytePolicy', 'Ignore'),
               key: secret.fromSecret,
               metadataPolicy: std.get(secret, 'metadataPolicy', 'None'),
-              property: std.get(secret, 'property', null),
+              property: std.get(secret, 'property', property),
             }),
           } for secret in secrets],
           [if std.length(allKeysFrom) > 0 then 'dataFrom']: [{
             extract: std.prune({
               conversionStrategy: std.get(secret, 'conversionStrategy', 'Default'),
               decodingStrategy: std.get(secret, 'decodingStrategy', 'None'),
+              nullBytePolicy: std.get(secret, 'nullBytePolicy', 'Ignore'),
               key: secret.fromSecret,
               metadataPolicy: std.get(secret, 'metadataPolicy', 'None'),
-              property: std.get(secret, 'property', null),
+              property: std.get(secret, 'property', property),
             }),
           } for secret in allKeysFrom],
           refreshInterval: '1h0m0s',

--- a/v2/tests/externalSecretsSecret_test.jsonnet
+++ b/v2/tests/externalSecretsSecret_test.jsonnet
@@ -5,11 +5,18 @@ local secrets = [
   {
     fromSecret: 'the-first-test-file',
     toKey: 'test-key',
+    property: 'test-property',
   },
 ];
 local allKeysFrom = [
   {
     fromSecret: 'test-file',
+  },
+];
+local allKeysFromWithProperty = [
+  {
+    fromSecret: 'test-file',
+    property: 'extract-property',
   },
 ];
 
@@ -22,9 +29,19 @@ local actual =
     secretStoreRef='some-store'
   );
 
+local actualWithExtractProperty =
+  application.new('test-app', 'foo.io/image', 8080)
+  + application.withEnvironmentVariablesFromExternalSecret(
+    name='test-external-secret',
+    secrets=secrets,
+    allKeysFrom=allKeysFromWithProperty,
+    secretStoreRef='some-store'
+  );
+
 local app = actual.items[0];
 local externalSecret = actual.items[1];
-local label = 'Test External Secret';
+local externalSecretWithExtractProperty = actualWithExtractProperty.items[1];
+local label = 'Test External Secret ';
 
 test.new(std.thisFile)
 + test.case.new(
@@ -60,5 +77,26 @@ test.new(std.thisFile)
   test=test.expect.eqDiff(
     actual=app.spec.envFrom[0].secret,
     expected=externalSecret.metadata.name,
+  )
+)
++ test.case.new(
+  name=label + 'external secret has correct remoteRef property',
+  test=test.expect.eqDiff(
+    actual=externalSecret.spec.data[0].remoteRef.property,
+    expected='test-property',
+  )
+)
++ test.case.new(
+  name=label + 'dataFrom.extract property is absent when not set',
+  test=test.expect.eqDiff(
+    actual=std.objectHas(externalSecret.spec.dataFrom[0].extract, 'property'),
+    expected=false,
+  )
+)
++ test.case.new(
+  name=label + 'dataFrom.extract property is set when provided',
+  test=test.expect.eqDiff(
+    actual=externalSecretWithExtractProperty.spec.dataFrom[0].extract.property,
+    expected='extract-property',
   )
 )


### PR DESCRIPTION
Støtt henting av properties i JSON-secrets. Eks: CloudSQL-modul v0.12.0+

## Description 📝
Støtter uthenting av en property fra en secret direkte

## Motivation and Context 💡
JSON-secrets som mapper til flere miljøvariabler blir enkle å håndtere i Argo, null rot nødvendig i appen.

## How Has This Been Tested? 🧪
Det kjører i Datamarkedsplassen i dev og prod nå.
Se https://github.com/kartverket/dask-datamarkedsplass/pull/512 for endring av modulversjon og tilhørende endring i dask-apps: https://github.com/kartverket/dask-apps/pull/120. Siden vi håndterer remapping av secrets i dask-apps slapp vi å gjøre kodeendringer i appen.

## Types of changes 🔄
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue) 🐛
- [x] New feature (non-breaking change which adds functionality) ✨
- [ ] Breaking change (fix or feature that would cause existing functionality to change) 💥

## Checklist: ✅
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project. 💅
- [ ] My changes do not break the existing tests 🧪
- [ ] I have updated the tests accordingly ➕ 
- [ ] My change requires a change to the documentation. 📚
- [ ] I have updated the documentation accordingly. 📝

## Questions: ❓
<!--- If you have some questions, put them under here pointwise. -->