### PR TITLE
Import utils from v2 in dbArchive

### DIFF
--- a/jsonnet/dbArchive.libsonnet
+++ b/jsonnet/dbArchive.libsonnet
@@ -1,5 +1,5 @@
 local argokit = import './argokit.libsonnet';
-local utils = import '../internal/utils.libsonnet';
+local utils = import '../v2/internal/utils.libsonnet';
 {
   dbArchiveJob(
     instanceName,


### PR DESCRIPTION
There is an issue, https://github.com/kartverket/argokit/issues/81, indicating dbArchive needs more work (?) to be implemented for v2. Not sure what would have to be adjusted. The dbArchive.jsonnet example now works, at least. Previously, it would give:

> "no match locally or in the Jsonnet library paths"