### PR TITLE
Add option to limit file permissions for secret as mount

### DIFF
--- a/v2/api-reference.md
+++ b/v2/api-reference.md
@@ -447,10 +447,11 @@ Legg til en `AzureADApplication`-ressurs og konfigurerer applikasjonen.
 ### `argokit.appAndObjects.application.withSecretAsMount()`
 Monter en eksisterende hemmelighet som filer på angitt sti.
 
-|navn|type|obligatorisk|standardverdi|beskrivelse|
-|-|-|-|-|-|
-|`secretName`|`string`|`true`| - |navn på hemmeligheten som skal monteres|
-|`mountPath`|`string`|`true`| - |stien hvor hemmeligheten skal monteres|
+| navn               | type     | obligatorisk | standardverdi | beskrivelse                                                      |
+|--------------------|----------|--------------|---------------|------------------------------------------------------------------|
+| `secretName`       | `string` | `true`       | -             | navn på hemmeligheten som skal monteres                          |
+| `mountPath`        | `string` | `true`       | -             | stien hvor hemmeligheten skal monteres                           |
+| `limitPermissions` | `bool`   | `false`      | `false`       | begrens filrettigheter til `600` i stedet for `644` som standard |
 
 **Eksempel:** [examples/mounts.jsonnet](https://github.com/kartverket/argokit/blob/main/v2/examples/mounts.jsonnet)
 

--- a/v2/lib/appAndObjects/mounts.libsonnet
+++ b/v2/lib/appAndObjects/mounts.libsonnet
@@ -6,8 +6,9 @@ local v = import '../../internal/validation.libsonnet';
   Parameters:
     - secretName: string - The name of the secret to mount.
     - mountPath: string - The path to the mount.
+    - limitPermissions: bool - Limit file permissions to '600' (optional, default is false and '644')
   */
-  withSecretAsMount(secretName, mountPath)::
+  withSecretAsMount(secretName, mountPath, limitPermissions=false)::
     v.string(secretName, 'secretName') +
     v.string(mountPath, 'mountPath') +
     {
@@ -17,6 +18,7 @@ local v = import '../../internal/validation.libsonnet';
             {
               mountPath: mountPath,
               secret: secretName,
+              [if limitPermissions then 'defaultMode']: std.parseOctal('0600'),
             },
           ],
         },

--- a/v2/tests/mounts_test.jsonnet
+++ b/v2/tests/mounts_test.jsonnet
@@ -10,6 +10,7 @@ local combinedMountApp =
   app
   + application.withSecretAsMount('secret-1', '/path/1')
   + application.withPersistentVolumeClaimAsMount('pvc-1', '/path/2');
+local secretMountWithDefaultModeApp = app + application.withSecretAsMount('my-secret', '/var/run/secrets/my-secret', true);
 
 test.new(std.thisFile)
 
@@ -49,5 +50,17 @@ test.new(std.thisFile)
         persistentVolumeClaim: 'pvc-1',
       },
     ]
+  )
+)
+
++ test.case.new(
+  name='withSecretAsMount overrides file permissions',
+  test=test.expect.eqDiff(
+    actual=secretMountWithDefaultModeApp.items[0].spec.filesFrom[0],
+    expected={
+      mountPath: '/var/run/secrets/my-secret',
+      secret: 'my-secret',
+      defaultMode: std.parseOctal('0600'),
+    }
   )
 )


### PR DESCRIPTION
## Description 📝
Add option to limit permissions to 600 instead of default of 644.

## Motivation and Context 💡
Some libraries (psycopg2 postgres client for Python) refuses to use client key if the file is readable by world.

## How Has This Been Tested? 🧪
Added testcase in mounts_test.jsonnet

## Types of changes 🔄
- [ ] Bug fix (non-breaking change which fixes an issue) 🐛
- [x] New feature (non-breaking change which adds functionality) ✨
- [ ] Breaking change (fix or feature that would cause existing functionality to change) 💥

## Checklist: ✅
- [x] My code follows the code style of this project. 💅
- [x] My changes do not break the existing tests 🧪
- [x] I have updated the tests accordingly ➕ 
- [x] My change requires a change to the documentation. 📚
- [x] I have updated the documentation accordingly. 📝